### PR TITLE
docs: correct the get_font_list() return shape and example

### DIFF
--- a/applications/halo/PROTOCOL.md
+++ b/applications/halo/PROTOCOL.md
@@ -1602,12 +1602,14 @@ Sets the current font for text rendering.
 
 Gets a list of available fonts.
 
-- **Returns:** `table` of font information
+- **Returns:** `table` mapping font id to font name: `{[0]="Dogica", [1]="DogicaBold"}`.
+  Note the keys start at 0 (matching `set_font`'s `font_id`), so `ipairs` —
+  which starts at index 1 — does not visit every entry.
 - **Example:**
   ```lua
   local fonts = frame.display.get_font_list()
-  for i, font in ipairs(fonts) do
-      print(font.id, font.name)
+  for id, name in pairs(fonts) do
+      print(id, name)
   end
   ```
 


### PR DESCRIPTION
The function pushes a table mapping font id to name with integer keys starting at 0 -- not an array of records. The documented example iterates with ipairs (which starts at index 1, so it never visits font 0) and reads font.id / font.name fields that are always nil. Document the real shape and iterate with pairs.

Found while truing the SDK emulator up against 0.8.8; the same fix has been applied to docs.brilliant.xyz (brilliantlabsAR/docs#72).
