### PR TITLE
ci: mark the container workspace safe for git so frame.GIT_TAG is populated

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -55,10 +55,15 @@ gh release download vX.Y.Z-<run#> -p '*release.signed.bin' -D <dir>
 ```
 
 Then run `tools/verify.py --name "<device>"` — it must print `fw X.Y.Z` and
-`repl-ok`. That's the whole check: release builds expose **no git hash** over
-the Lua API (`frame.FIRMWARE_VERSION` is all there is); provenance is the
-MCUboot image hash `ota_flash.py` printed plus the fact you flashed the CI
-asset. Then roll out to production units as desired (their `main.lua` apps
+`repl-ok`. For provenance, also probe `frame.GIT_TAG` over the REPL: it is
+the app repo's **12-char commit hash** at build time (`APP_BUILD_VERSION`
+from `git describe --abbrev=12 --always` — hash-only, because plain
+`git describe` ignores lightweight tags and this repo's tags are
+lightweight). It should match the built commit; an **empty string** means
+the build's `git describe` silently failed (CI images of 0.8.8 and earlier
+all have this — fixed by the `safe.directory` line in the workflow). The
+MCUboot image hash `ota_flash.py` prints is the other provenance anchor.
+Then roll out to production units as desired (their `main.lua` apps
 survive OTA).
 
 ## 4. Tag

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -70,6 +70,11 @@ jobs:
               if [ -n \"\$GH_TOKEN\" ]; then
                 git config --global url.\"https://x-access-token:\${GH_TOKEN}@github.com/\".insteadOf \"https://github.com/\"
               fi
+              # The rsynced checkout keeps the host runner's UID, so git run
+              # as root inside the container fails with 'dubious ownership'.
+              # Zephyr's gen_version_h swallows that failure, leaving
+              # APP_BUILD_VERSION -- and therefore frame.GIT_TAG -- empty.
+              git config --global --add safe.directory '*'
               west update
 
               cd /opt/workspace/project/applications/halo


### PR DESCRIPTION
Every image built by `build-and-release.yml` ships with an empty `frame.GIT_TAG`.

**Cause:** the workflow rsyncs the checkout into the build container, preserving the host runner's UID. Git inside the container runs as root and refuses the repo with `fatal: detected dubious ownership in repository at '/opt/workspace/project'`. Zephyr's `gen_version_h.cmake` treats a failed `git describe` as a STATUS-level event and generates an empty `APP_BUILD_VERSION`, which `lua_version.c` stringifies into `frame.GIT_TAG` — so the build succeeds with `GIT_TAG == ""`. Both builds in the 0.8.8 run logged the failure.

**Fix:** `git config --global --add safe.directory '*'` in the container script, next to the existing global-git-config handling.

Also corrects the release skill's verification section, which wrongly claimed release builds expose no git hash: `frame.GIT_TAG` is the app repo's 12-char commit hash (`git describe --abbrev=12 --always`; hash-only since plain `describe` ignores lightweight tags). An empty `GIT_TAG` identifies a pre-fix CI image (0.8.8 and earlier).
