### PR TITLE
ble_lua: fix length underflow in the RX write handler

### DIFF
--- a/modules/halo/src/ble_lua.c
+++ b/modules/halo/src/ble_lua.c
@@ -241,6 +241,10 @@ static void on_att_val_set(uint8_t conidx, uint8_t user_lid, uint16_t token, uin
 		struct ring_buf *target_ring;
 		struct k_sem *target_sem;
 
+		if (len == 0) {
+			break;
+		}
+
 		if (halo_ble_is_paired() == false) {
 			LOG_WRN("Write attempt while not paired - rejected");
 			status = ATT_ERR_INSUFF_AUTHEN;
@@ -281,6 +285,7 @@ static void on_att_val_set(uint8_t conidx, uint8_t user_lid, uint16_t token, uin
 			} else {
 				target_ring = &lua_ctx.repl_rx_ring;
 				target_sem = &lua_ctx.repl_rx_sem;
+				len++; // reserve for '\n'
 			}
 		}
 


### PR DESCRIPTION
## Change
Ignore zero-length writes, and reserve for the newline on the continuation path as the `offset==0` path already does.
## Why
`on_att_val_set()` stores `len - 1` bytes on paths where `len` was never incremented.

`len` is incremented once, on the `offset == 0` REPL path, to reserve room for the newline the handler appends. Two other paths reach the same `ring_buf_put()` calls without it.

Zero-length write. `len == 0` fails the `offset == 0 && len > 0` test and falls through to the continuation branch. `len - 1` promotes to `int -1` and reaches `ring_buf_put()`'s uint32_t size parameter as 0xFFFFFFFF; `ring_buf_put()` copies `MIN(size, free_space)` bytes out of a zero-length buffer, draining the ring's free space from adjacent memory: 1024 bytes for the REPL ring, 4096 for the data ring. When `current_rx_ring` already points at the data ring, the `data[0] == HALO_LUA_CTRL_DATA_MARKER` test that selects that branch also reads out of bounds before the copy does.

Those bytes land in the REPL input and are parsed as Lua. Parse errors are written back to the connected peer over LUA TX.

Continuation fragment. `offset != 0` reaches the same call with `len` un-incremented, so each fragment loses its last byte and gets a newline in its place, splitting one statement into several.

Both cases complete with `GAP_ERR_NO_ERROR`. Nothing is reported to the host.

## Reproduction

A harness transcribing the handler body against Zephyr's own `ring_buffer.c`, at this firmware's ring sizes:

| | current | with this patch |
|---|---|---|
| zero-length write, REPL ring | 1025 bytes out of bounds | 0 |
| zero-length write, data ring | 4097 bytes out of bounds | 0 |
| two-fragment print('hello world') | print('hel\nlo world'\n | print('hel\nlo world')\n |

The BLE stack is not simulated. The `(offset, data, len)` triples are what an ATT write hands the callback, and everything downstream of that is executed. The firmware builds clean with the patch. It has not been run on hardware (My glasses are still in the mail 🙂).

## Followup 

### Is either input reachable through the ROM?
I could not determine from the published headers whether the GATT server forwards a zero-length write to cb_att_val_set, or whether it delivers prepared-write fragments per-offset or reassembled. What I could establish: `LUA_IDX_RX_VAL` supplies `CFG_ATT_VAL_MAX` (512, bit 15 clear) where every other writable attribute sets `GATT_ATT_NO_OFFSET_BIT`, so offset writes are authorised on this handle. Separately, `gatt_cbs.cb_att_info_get` is NULL here and in every Alif sample I looked at, and that callback is documented as being invoked during a write procedure, worth a look if the ROM calls it.

### Should offset writes be refused outright?
This patch stops the byte loss, but a newline is still appended per fragment, so a fragmented write still arrives as several statements. `cb_att_val_set` provides no end-of-write signal, so the newline cannot be placed correctly. Adding `OPT(NO_OFFSET) | CFG_ATT_VAL_MAX` to `LUA_IDX_RX_VAL` and `LUA_IDX_AUDIO_RX_VAL` would refuse them and match the rest of the database. That changes the behaviour of a public characteristic, so it is left out of this patch.