### PR TITLE
battery: steadier level reporting

### DIFF
--- a/applications/halo/tests/battery/battery_common.py
+++ b/applications/halo/tests/battery/battery_common.py
@@ -137,6 +137,10 @@ class BatteryLink:
             print_response_handler=lambda _s: None,
             disconnect_handler=self._on_disconnect,
         )
+        # Stop the resident main.lua before any REPL round-trip: its prints
+        # arrive on the same channel and race our await_print reads
+        # (break-before-probe; disconnect() resets the VM so the app resumes).
+        await self._ble.send_break_signal()
         return self._name
 
     async def reconnect(self, attempts: int, delay: float, scan_timeout: float = 5.0) -> bool:
@@ -193,6 +197,9 @@ class BatteryLink:
     async def disconnect(self):
         try:
             if self._ble is not None and self._ble.is_connected():
+                # Restart the Lua VM so the main.lua we stopped on connect
+                # resumes; leave the device as we found it.
+                await self._ble.send_reset_signal()
                 await self._ble.disconnect()
         except Exception:
             pass

--- a/drivers/sensor/alif_vbat.c
+++ b/drivers/sensor/alif_vbat.c
@@ -14,6 +14,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <math.h>
+#include <string.h>
 
 LOG_MODULE_REGISTER(ALIF_VBAT, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -49,9 +50,13 @@ LOG_MODULE_REGISTER(ALIF_VBAT, CONFIG_SENSOR_LOG_LEVEL);
 
 #define MAX_NUM_THRESHOLD (6)
 
+/* Conversions averaged per fetch */
+#define VBAT_ADC_SAMPLES (4)
+
 static uint32_t comp_value[MAX_NUM_THRESHOLD] = {0};
 static uint32_t buffer[8];
 static uint32_t m_samplings_done;
+static uint32_t sample_accum;
 static uint8_t comparator;
 
 /* Structure to hold discharge curve points */
@@ -124,9 +129,12 @@ static enum adc_action adc_call_back(const struct device *dev, const struct adc_
 		comp_value[5] += 1;
 	}
 
+	/* Each repeat overwrites the same buffer slot, so accumulate here and
+	 * average in vbat_sample_fetch(). */
+	sample_accum += buffer[find_lsb_set(sequence->channels) - 1];
 	++m_samplings_done;
 
-	if (m_samplings_done < 2) {
+	if (m_samplings_done < VBAT_ADC_SAMPLES) {
 		return ADC_ACTION_REPEAT;
 	} else {
 		return ADC_ACTION_FINISH;
@@ -362,14 +370,21 @@ static int vbat_sample_fetch(const struct device *dev, enum sensor_channel chan)
 				   .buffer_size = sizeof(buffer),
 				   .channels = (1 << cfg->channel)};
 
+	/* Per-fetch scratch: the callback accumulates VBAT_ADC_SAMPLES
+	 * conversions into sample_accum. */
+	m_samplings_done = 0;
+	sample_accum = 0;
+	memset(comp_value, 0, sizeof(comp_value));
+
 	ret = adc_read(cfg->adc, &seq);
 	if (ret != 0) {
 		LOG_ERR("ADC read failed: %d", ret);
 		goto error;
 	}
 
-	/* Convert raw ADC to voltage */
-	int32_t adc_mv = buffer[cfg->channel] * 1800 / 4095;
+	/* Average the burst, then convert raw ADC counts to voltage */
+	int32_t adc_mv = (int32_t)((uint64_t)sample_accum * 1800 /
+				   (4095u * VBAT_ADC_SAMPLES));
 
 	data->raw_voltage = adc_mv;
 	data->actual_voltage = data->raw_voltage * cfg->full_ohms / cfg->output_ohms;

--- a/modules/halo/src/battery_manager.c
+++ b/modules/halo/src/battery_manager.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(halo_battery, CONFIG_HALO_LOG_LEVEL);
 /* EMA Filter configuration */
 #define BATTERY_FILTER_ALPHA_U16   6553    /* Alpha = 65535/(N+1), N=9 for ~10 sample window */
 #define FILTER_INIT_CYCLES         3       /* Number of cycles to initialize EMA */
+#define BATTERY_SEED_DELAY_MS      15000   /* Seed the EMA from post-boot readings only */
 
 /* Battery manager context */
 static struct {
@@ -117,6 +118,13 @@ static uint8_t apply_battery_filter(uint8_t raw_percentage)
 
 	/* Initialize EMA with first readings */
 	if (!bat_mgr_ctx.ema_initialized) {
+		/* Seed only from post-boot steady-state readings; report the raw
+		 * value until then. Voltage, charging state and callbacks are
+		 * unaffected - only the level filter waits. */
+		if (k_uptime_get() < BATTERY_SEED_DELAY_MS) {
+			return raw_percentage;
+		}
+
 		bat_mgr_ctx.battery_percentage_ema = raw_percentage;
 		bat_mgr_ctx.ema_init_counter++;
 

--- a/modules/halo/src/battery_manager.c
+++ b/modules/halo/src/battery_manager.c
@@ -20,6 +20,8 @@ LOG_MODULE_REGISTER(halo_battery, CONFIG_HALO_LOG_LEVEL);
 #define BATTERY_FILTER_ALPHA_U16   6553    /* Alpha = 65535/(N+1), N=9 for ~10 sample window */
 #define FILTER_INIT_CYCLES         3       /* Number of cycles to initialize EMA */
 #define BATTERY_SEED_DELAY_MS      15000   /* Seed the EMA from post-boot readings only */
+#define BATTERY_CONVERGE_CONFIRM   3       /* Counter-direction samples before converging */
+#define BATTERY_CONVERGE_STEP      1       /* Max %-points per update against direction */
 
 /* Battery manager context */
 static struct {
@@ -38,6 +40,7 @@ static struct {
 	uint8_t battery_percentage_ema;    /* Current EMA value */
 	bool ema_initialized;              /* EMA initialization flag */
 	uint8_t ema_init_counter;          /* Counter for init cycles */
+	uint8_t converge_counter;          /* Consecutive counter-direction samples */
 
 	/* Update management */
 	struct k_work_delayable update_work;
@@ -80,13 +83,15 @@ static void battery_trigger_handler(const struct device *dev, const struct senso
  */
 static uint8_t update_ema_filter(uint8_t current_ema, uint8_t new_value, bool is_charging)
 {
-	/* Handle edge case transitions directly (near 0% or 100%) */
-	if ((!is_charging && (current_ema <= 5)) || (is_charging && (current_ema >= 95))) {
-		if (is_charging) {
-			return (new_value > current_ema) ? current_ema + 1 : current_ema;
-		} else {
-			return (new_value < current_ema) ? current_ema - 1 : current_ema;
-		}
+	/* Near the endpoints, step at most 1% per update in the charge direction
+	 * so the last few percent move smoothly. Readings against the charge
+	 * direction fall through to the plain EMA and are rate-limited by the
+	 * convergence path in apply_battery_filter(). */
+	if (!is_charging && current_ema <= 5 && new_value < current_ema) {
+		return current_ema - 1;
+	}
+	if (is_charging && current_ema >= 95 && new_value > current_ema) {
+		return current_ema + 1;
 	}
 
 	/* Constant coefficient Alpha for EMA calculation, scaled to 16 bit.
@@ -102,12 +107,13 @@ static uint8_t update_ema_filter(uint8_t current_ema, uint8_t new_value, bool is
 }
 
 /**
- * @brief Apply battery percentage filter with charging direction enforcement
- * 
- * Ensures that:
- * - When charging: percentage can only increase or stay same
- * - When not charging: percentage can only decrease or stay same
- * 
+ * @brief Apply battery percentage filter with charge-direction weighting
+ *
+ * Movement with the charge direction (down while discharging, up while
+ * charging) follows the EMA directly; movement against it converges toward
+ * the measured value at a bounded rate once confirmed by consecutive
+ * samples.
+ *
  * @param raw_percentage Raw percentage from sensor
  * @return Filtered percentage value
  */
@@ -138,24 +144,30 @@ static uint8_t apply_battery_filter(uint8_t raw_percentage)
 	}
 
 	/* Apply EMA filter to smooth out percentage changes */
-	uint8_t filtered = update_ema_filter(bat_mgr_ctx.battery_percentage_ema, 
+	uint8_t filtered = update_ema_filter(bat_mgr_ctx.battery_percentage_ema,
 					     raw_percentage, is_charging);
 
-	/* Enforce charging direction: charging can only increase, discharging can only decrease */
-	if (is_charging) {
-		/* When charging: only allow increase or stay same */
-		if (filtered >= bat_mgr_ctx.battery_percentage_ema) {
-			result = filtered;
+	/* Movement with the charge direction (down while discharging, up while
+	 * charging) is accepted as filtered. Movement against it converges at a
+	 * bounded rate: after BATTERY_CONVERGE_CONFIRM consecutive
+	 * counter-direction samples, step at most BATTERY_CONVERGE_STEP
+	 * %-points per update toward the measured value. */
+	uint8_t current = bat_mgr_ctx.battery_percentage_ema;
+	bool with_direction = is_charging ? (filtered >= current) : (filtered <= current);
+
+	if (with_direction) {
+		result = filtered;
+		bat_mgr_ctx.converge_counter = 0;
+	} else if (++bat_mgr_ctx.converge_counter >= BATTERY_CONVERGE_CONFIRM) {
+		if (filtered > current) {
+			result = current + MIN(BATTERY_CONVERGE_STEP,
+					       (uint8_t)(filtered - current));
 		} else {
-			result = bat_mgr_ctx.battery_percentage_ema;
+			result = current - MIN(BATTERY_CONVERGE_STEP,
+					       (uint8_t)(current - filtered));
 		}
 	} else {
-		/* When not charging: only allow decrease or stay same */
-		if (filtered <= bat_mgr_ctx.battery_percentage_ema) {
-			result = filtered;
-		} else {
-			result = bat_mgr_ctx.battery_percentage_ema;
-		}
+		result = current;
 	}
 
 	/* Update EMA state */


### PR DESCRIPTION
Steadier battery level reporting:

- The reported-level filter now seeds from readings taken after the system reaches steady state (15 s after boot) instead of the first three fetches. Until seeding completes the raw measured level is reported directly.
- The charge-direction filter previously held the reported level monotonic between charger events; it now allows bounded convergence toward the measured state of charge (1 % per update after three consecutive confirming samples) in both directions.
- Each battery fetch now averages a four-conversion ADC burst, with the per-fetch counters reset per read.
- The battery test harness quiesces the resident application during REPL round-trips and resumes it on disconnect.

Verified on the dev kit and a production unit.
