### PR TITLE
Speaker loudness and protection-envelope enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ release pages and tags are not publicly reachable.
 - `frame.speaker.start{gain=0..12}`: per-stream digital pre-gain into the
   protection limiter — lifts quiet sources (un-normalized TTS) toward the
   loudness ceiling, compresses hot ones; transient per stream
+- `frame.speaker.start{budget=10..100}`: per-stream energy-budget
+  override up to a firmware-clamped maximum — higher = louder ceiling at
+  more battery current; any override engages the fast limiter attack
+  that makes raised budgets safe (bench-validated at 100 against
+  worst-case content); all protection stays active; transient per stream
+- True-peak clamp on the protection chain's weighted drive
+  (`MAX98357A_AUDIO_PROTECT_PEAK_CAP_PERCENT`, default 300 %): backstop
+  against tall transient spikes inside the energy limiter's integration
+  window
 - Display-aware speaker energy budget: while the display is out of power
   save its current load shares the battery-protection IC with the
   speakers, so the audio budget is reduced (default 20 points,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,33 @@ release pages and tags are not publicly reachable.
 
 ## [Unreleased]
 
+### Added
+
+- `frame.speaker.start{gain=0..12}`: per-stream digital pre-gain into the
+  protection limiter — lifts quiet sources (un-normalized TTS) toward the
+  loudness ceiling, compresses hot ones; transient per stream
+- Display-aware speaker energy budget: while the display is out of power
+  save its current load shares the battery-protection IC with the
+  speakers, so the audio budget is reduced (default 20 points,
+  Kconfig-tunable) and restored when the display sleeps, ramped smoothly
+  even mid-stream
+- Runtime protection-chain tuning API for bench/listening builds
+  (`MAX98357A_AUDIO_PROTECT_TUNING`, off in production), and a
+  psychoacoustic bass enhancer stage (off by default)
+
+### Changed
+
+- Speaker voicing rebalanced for loudness: deeper cuts in the
+  vibrotactile lows, +4 dB top band, protection HPF 130 → 200 Hz —
+  blinded on-head A/B: louder speech at equal buzz
+- Speaker protection sidechain weights recalibrated from bench current
+  measurements: supply current tracks drive amplitude (not frequency),
+  so the per-band weights are now uniform and the energy budget caps
+  current honestly for any spectrum
+- Speaker limiter releases upward when its budget rises mid-clamp
+  (previously the gain ratcheted down until the content itself went
+  quiet)
+
 ## [0.8.8] - 2026-08-17
 
 ### Added

--- a/applications/halo/PROTOCOL.md
+++ b/applications/halo/PROTOCOL.md
@@ -1106,6 +1106,7 @@ Initializes the speaker.
   | `duration` | number | 1000 | LC3 frame duration (µs/10, matching the Alif LC3 enum: 750 = 7.5 ms, 1000 = 10 ms) |
   | `bitrate` | number | 16000 | LC3 bitrate (multiple of 8000, ≤96000) |
   | `volume` | number | 50 | Volume (0–100%) |
+  | `gain` | number | 0 | Digital pre-gain into the protection limiter (0–12 dB). Lifts quiet sources (e.g. un-normalized TTS) toward the loudness ceiling; hot sources are compressed instead of getting louder. Transient: applies to this stream only. |
 
 - **Returns:** `nil`
 - **Errors:**
@@ -1116,6 +1117,7 @@ Initializes the speaker.
   - Throws an error if encoder is "lc3" and duration is not 750 or 1000
   - Throws an error if encoder is "lc3" and bitrate is not a multiple of 8000 or > 96000
   - Throws an error if volume is not 0-100
+  - Throws an error if gain is not 0-12
   - Throws an error if speaker initialization fails
   - Throws an error if LC3 decoder creation fails
   - Throws an error if memory allocation fails

--- a/applications/halo/PROTOCOL.md
+++ b/applications/halo/PROTOCOL.md
@@ -1107,6 +1107,7 @@ Initializes the speaker.
   | `bitrate` | number | 16000 | LC3 bitrate (multiple of 8000, ≤96000) |
   | `volume` | number | 50 | Volume (0–100%) |
   | `gain` | number | 0 | Digital pre-gain into the protection limiter (0–12 dB). Lifts quiet sources (e.g. un-normalized TTS) toward the loudness ceiling; hot sources are compressed instead of getting louder. Transient: applies to this stream only. |
+  | `budget` | number | configured | Per-stream energy-budget override (10–100): higher = louder ceiling, more battery current. Any override engages the fast limiter attack that makes raised budgets safe; all protection stays active, and the value is clamped to a firmware-configured maximum. `budget=100` with `gain=12` is the loudest supported voice. Transient: applies to this stream only. |
 
 - **Returns:** `nil`
 - **Errors:**
@@ -1118,6 +1119,7 @@ Initializes the speaker.
   - Throws an error if encoder is "lc3" and bitrate is not a multiple of 8000 or > 96000
   - Throws an error if volume is not 0-100
   - Throws an error if gain is not 0-12
+  - Throws an error if budget is not 10-100
   - Throws an error if speaker initialization fails
   - Throws an error if LC3 decoder creation fails
   - Throws an error if memory allocation fails

--- a/drivers/audio/max98357a/Kconfig
+++ b/drivers/audio/max98357a/Kconfig
@@ -102,6 +102,26 @@ config MAX98357A_AUDIO_PROTECT_BUDGET_PERCENT
 	  largest value that stays below the protection IC's trip point with
 	  margin.
 
+config MAX98357A_AUDIO_PROTECT_PEAK_CAP_PERCENT
+	int "True-peak weighted-drive cap, percent of full scale (0 disables)"
+	default 300
+	range 0 1000
+	help
+	  Instantaneous cap on the current-weighted output amplitude, in the
+	  same units as the energy budget. The energy limiter's sidechain
+	  integrates over ~PROTECT_ENV_MS and is blind to the first
+	  milliseconds of a transient, but the battery protection IC's
+	  short-circuit comparator reacts in hundreds of microseconds -
+	  on hardware, a pregain-boosted fricative onset latched the IC
+	  while sustained content at the same budget survived. This clamp
+	  reacts within one sample (instant attack, ~4 ms release).
+
+	  Normal speech peaks reach roughly 150-200 % weighted; the
+	  transients that tripped the IC computed at 400 %+. The default
+	  300 sits between: inaudible in normal operation, engaged only on
+	  trip-class spikes. Must sit above the energy budget (the budget
+	  needs crest headroom to do its job).
+
 config MAX98357A_AUDIO_PROTECT_DISPLAY_BUDGET_DROP
 	int "Budget reduction while the display is active (percent points)"
 	default 20

--- a/drivers/audio/max98357a/Kconfig
+++ b/drivers/audio/max98357a/Kconfig
@@ -52,10 +52,10 @@ config MAX98357A_AUDIO_PROTECTION_EQ
 	help
 	  Protect the bone-conduction transducers (and the battery protection
 	  IC) with a DSP chain applied post-volume, so thresholds reference
-	  absolute output level: 2nd-order HPF, mild static voicing EQ
-	  (half-depth issue #180 curve), a current-proxy energy limiter whose
-	  sidechain approximates transducer current draw vs frequency, an
-	  onset ramp, and a soft-knee true-peak clipper.
+	  absolute output level: 2nd-order HPF, static voicing EQ (loudness
+	  rebalance toward the audible bands), a current-proxy energy limiter
+	  whose bench-calibrated sidechain tracks transducer drive amplitude,
+	  an onset ramp, and a soft-knee true-peak clipper.
 
 	  Replaces the previous static EQ + instant peak limiter: protection
 	  now tracks short-term weighted signal ENERGY (what actually trips
@@ -66,13 +66,17 @@ if MAX98357A_AUDIO_PROTECTION_EQ
 
 config MAX98357A_AUDIO_PROTECT_HPF_HZ
 	int "Protection high-pass cutoff (Hz), 0 disables"
-	default 130
+	default 200
 	range 0 500
 	help
-	  2nd-order Butterworth high-pass removing DC/subsonic content below
-	  the transducer resonance, where drive current is pure waste. Keep
-	  below ~150 Hz so TTS voice fundamentals stay intact; the energy
-	  limiter handles protection above this frequency.
+	  2nd-order Butterworth high-pass removing content below the
+	  bone-conduction transducer's efficient region, where drive current
+	  buys felt vibration rather than audible loudness. 200 Hz was chosen
+	  by blinded on-head A/B together with the rebalanced voicing curve:
+	  louder speech at equal buzz. Voice fundamentals below the cutoff are
+	  deliberately traded away; the psychoacoustic bass enhancer
+	  (MAX98357A_AUDIO_BASS_ENHANCE_PERCENT) can restore perceived
+	  fullness without the current draw.
 
 config MAX98357A_AUDIO_PROTECT_BUDGET_PERCENT
 	int "Energy limiter budget, percent of full scale"
@@ -80,17 +84,21 @@ config MAX98357A_AUDIO_PROTECT_BUDGET_PERCENT
 	range 10 100
 	help
 	  Current budget for the energy limiter, as a percentage of int16 full
-	  scale for a hypothetical weight-1.0 signal. All bands carry current
-	  weights of 2.0..5.6 (highest below 425 Hz), so e.g. a sustained
-	  >= 1.5 kHz sine is allowed budget/2 of full scale and a 300 Hz sine
-	  budget/5.6 - protection lands hardest where the current is drawn.
+	  scale for a hypothetical weight-1.0 signal. All bands carry a
+	  uniform current weight of 3.0 (bench calibration showed supply
+	  current tracks drive amplitude, not frequency), so a sustained sine
+	  in any band is allowed budget/3 of full scale.
 
-	  Calibrate on the bench: play full-scale sine sweeps, BROADBAND
-	  NOISE, and real TTS at max volume (stereo, worst case), measure
-	  battery current, and pick the largest value that stays below the
-	  battery protection IC's trip point with margin. Noise coverage is
-	  essential - HF/broadband content draws more system current than
-	  sine-sweep models predict (Class-D losses).
+	  Bench-calibrated at 3.7 V through the full chain: audio draw at the
+	  budget-80 ceiling measured ~72 mA above baseline, which keeps the
+	  per-pack share plus quiescent system load under the battery
+	  protection IC's minimum over-discharge trip (50 mA @ 20 ms) with
+	  the display in power save.
+
+	  To recalibrate: play full-scale sine sweeps, BROADBAND NOISE, and
+	  real TTS at max volume, measure battery current, and pick the
+	  largest value that stays below the protection IC's trip point with
+	  margin.
 
 config MAX98357A_AUDIO_PROTECT_ENV_MS
 	int "Energy limiter integration window (ms)"

--- a/drivers/audio/max98357a/Kconfig
+++ b/drivers/audio/max98357a/Kconfig
@@ -108,19 +108,23 @@ config MAX98357A_AUDIO_PROTECT_PEAK_CAP_PERCENT
 	range 0 1000
 	help
 	  Instantaneous cap on the current-weighted output amplitude, in the
-	  same units as the energy budget. The energy limiter's sidechain
-	  integrates over ~PROTECT_ENV_MS and is blind to the first
-	  milliseconds of a transient, but the battery protection IC's
-	  short-circuit comparator reacts in hundreds of microseconds -
-	  on hardware, a pregain-boosted fricative onset latched the IC
-	  while sustained content at the same budget survived. This clamp
-	  reacts within one sample (instant attack, ~4 ms release).
+	  same units as the energy budget: instant attack (single sample),
+	  ~4 ms release. Guards against tall narrow transients (e.g.
+	  decoder-garbage clicks) that the energy sidechain's ~PROTECT_ENV_MS
+	  integration window would let through.
 
-	  Normal speech peaks reach roughly 150-200 % weighted; the
-	  transients that tripped the IC computed at 400 %+. The default
-	  300 sits between: inaudible in normal operation, engaged only on
-	  trip-class spikes. Must sit above the energy budget (the budget
-	  needs crest headroom to do its job).
+	  Bench characterisation nuance: the battery-IC trips observed with
+	  pregain-boosted fricatives at budget 100 were caused by drive
+	  DURATION at ~250 % for the few ms the integrator takes to
+	  converge, not by peak height - this cap alone did not prevent
+	  them (a shorter PROTECT_ENV_MS did). Keep the cap as the tall-
+	  spike backstop; treat the integration window as the lever for
+	  high-budget fricative exposure.
+
+	  Normal speech peaks reach roughly 150-200 % weighted; the default
+	  300 stays above them (engaged 0 frames in all bench content), so
+	  it is inaudible in normal operation. Must sit above the energy
+	  budget (the budget needs crest headroom to do its job).
 
 config MAX98357A_AUDIO_PROTECT_DISPLAY_BUDGET_DROP
 	int "Budget reduction while the display is active (percent points)"

--- a/drivers/audio/max98357a/Kconfig
+++ b/drivers/audio/max98357a/Kconfig
@@ -128,6 +128,37 @@ config MAX98357A_AUDIO_PROTECT_RAMP_MS
 	  turn-on inrush current so it does not coincide with a full-level
 	  first buffer (a classic battery-protection trip scenario).
 
+config MAX98357A_AUDIO_BASS_ENHANCE_PERCENT
+	int "Psychoacoustic bass harmonic drive (percent), 0 disables"
+	default 0
+	range 0 200
+	help
+	  Recover perceived bass fullness without the current draw: the
+	  60-240 Hz band (which the HPF and protection remove from the
+	  transducer) is full-wave rectified to generate even harmonics,
+	  band-shaped into 180-900 Hz and mixed back in before the HPF.
+	  The ear reconstructs the missing fundamental from the harmonic
+	  series, so TTS voice sounds full while the transducer is never
+	  driven at the frequencies that trip the battery IC.
+
+	  The harmonics enter the chain ahead of the sidechain and limiter,
+	  so this cannot raise output energy past the protection budget.
+
+	  100 mixes the shaped harmonics at unity relative to the extracted
+	  band; tune by ear (60-120 is a sensible range). Note the lower
+	  half of the harmonic band (180-425 Hz) is inside the vibrotactile
+	  range, so verify felt vibration (not just sound) when raising it.
+
+config MAX98357A_AUDIO_PROTECT_TUNING
+	bool "Runtime protection-chain tuning API (bench/lab builds)"
+	default n
+	help
+	  Expose max98357a_audio_protect_tune()/get()/stats(): runtime
+	  overrides for the HPF cutoff, energy budget, limiter timing, static
+	  voicing gains and sidechain current weights, plus a digital pre-gain
+	  and limiter-activity telemetry. For bench characterisation and
+	  listening-test builds; leave off in production images.
+
 endif # MAX98357A_AUDIO_PROTECTION_EQ
 
 endif # MAX98357A_AUDIO

--- a/drivers/audio/max98357a/Kconfig
+++ b/drivers/audio/max98357a/Kconfig
@@ -93,12 +93,37 @@ config MAX98357A_AUDIO_PROTECT_BUDGET_PERCENT
 	  budget-80 ceiling measured ~72 mA above baseline, which keeps the
 	  per-pack share plus quiescent system load under the battery
 	  protection IC's minimum over-discharge trip (50 mA @ 20 ms) with
-	  the display in power save.
+	  the display in power save. While the display is active its extra
+	  load rides the same protection IC, so the effective budget is
+	  reduced by MAX98357A_AUDIO_PROTECT_DISPLAY_BUDGET_DROP points.
 
 	  To recalibrate: play full-scale sine sweeps, BROADBAND NOISE, and
 	  real TTS at max volume, measure battery current, and pick the
 	  largest value that stays below the protection IC's trip point with
 	  margin.
+
+config MAX98357A_AUDIO_PROTECT_DISPLAY_BUDGET_DROP
+	int "Budget reduction while the display is active (percent points)"
+	default 20
+	range 0 60
+	help
+	  While the display is out of power save, its supply current (bench:
+	  ~19 mA above the idle baseline, ~30 mA total system load) rides the
+	  same battery-protection IC as the audio path's larger share. The
+	  effective energy-limiter budget is reduced by this many points for
+	  as long as the display is active, and restored when it returns to
+	  power save - applied as a smooth ramped step even mid-stream.
+
+	  With the calibrated budget->current mapping, the default 20-point
+	  drop (80 -> 60) keeps the worst-case display-on draw near the
+	  protection IC's minimum trip threshold; raise the drop if a unit
+	  with a low-trip IC sample still cuts out during display-on
+	  playback, or set 0 to disable the coupling entirely.
+
+	  Note the audible consequence: content played with the display on
+	  is up to ~2 dB quieter at the loudness ceiling than display-off
+	  playback. Senders that want full speech loudness should blank the
+	  display during playback.
 
 config MAX98357A_AUDIO_PROTECT_ENV_MS
 	int "Energy limiter integration window (ms)"

--- a/drivers/audio/max98357a/Kconfig
+++ b/drivers/audio/max98357a/Kconfig
@@ -149,6 +149,35 @@ config MAX98357A_AUDIO_PROTECT_DISPLAY_BUDGET_DROP
 	  playback. Senders that want full speech loudness should blank the
 	  display during playback.
 
+config MAX98357A_AUDIO_PROTECT_STREAM_BUDGET_MAX
+	int "Highest per-stream energy budget an app may request"
+	default 100
+	range 10 100
+	help
+	  Upper clamp for the per-stream budget override
+	  (frame.speaker.start{budget=N}). Requests above this are limited
+	  here, so the product can restrict the app-reachable envelope
+	  without an API change. The maximum-loudness envelope
+	  (budget 100 + the fast integration window below) is
+	  bench-validated: survived hot full-scale speech with +12 dB
+	  pre-gain on the low-trip-sample unit (display off; the display
+	  budget drop still applies on top).
+
+config MAX98357A_AUDIO_PROTECT_STREAM_BUDGET_ENV_MS
+	int "Integration window while a stream budget override is active (ms)"
+	default 1
+	range 1 10
+	help
+	  Sidechain integration window used whenever a stream requests a
+	  budget override. The short window is what makes raised budgets
+	  safe: the battery IC's effective trip window measured a few
+	  milliseconds, and pre-gain-boosted fricative onsets latch it
+	  during the sidechain's convergence time. 1 ms clamps those onsets
+	  ~3x faster than the default window; the cost is slightly harder
+	  limiting of brief legitimate transients - acceptable in an
+	  explicitly loudness-first stream, and harmlessly conservative
+	  when the requested budget is below the shipped default.
+
 config MAX98357A_AUDIO_PROTECT_ENV_MS
 	int "Energy limiter integration window (ms)"
 	default 3

--- a/drivers/audio/max98357a/include/max98357a_audio.h
+++ b/drivers/audio/max98357a/include/max98357a_audio.h
@@ -137,6 +137,21 @@ struct max98357a_protect_tuning {
 void max98357a_audio_set_display_active(bool active);
 
 /**
+ * @brief Set the per-stream energy-budget override (percent, 0 = none).
+ *
+ * Clamped to [10, MAX98357A_AUDIO_PROTECT_STREAM_BUDGET_MAX]. Any
+ * override also selects the fast integration window
+ * (MAX98357A_AUDIO_PROTECT_STREAM_BUDGET_ENV_MS) - that is what makes
+ * raised budgets safe against transient exposure. Protection stays
+ * fully active: display budget drop, current weights, energy limiter
+ * and true-peak clamp all apply. Transient by convention: the halo
+ * audio_stream layer clears it on every speaker acquisition. Applied
+ * when the chain is (re)built - set it between configure and stream
+ * start. No-op when the protection chain is disabled.
+ */
+void max98357a_audio_set_stream_budget(int budget_percent);
+
+/**
  * @brief Set the per-stream digital pre-gain (dB*10, clamped to 0..+120).
  *
  * Applied at the head of the protection chain; the limiter sidechain sees

--- a/drivers/audio/max98357a/include/max98357a_audio.h
+++ b/drivers/audio/max98357a/include/max98357a_audio.h
@@ -123,6 +123,19 @@ struct max98357a_protect_tuning {
 };
 
 /**
+ * @brief Tell the audio path whether the display is out of power save.
+ *
+ * While active, the display's supply current rides the same battery
+ * protection IC as the speakers, so the protection chain's energy budget
+ * is reduced by MAX98357A_AUDIO_PROTECT_DISPLAY_BUDGET_DROP points (a
+ * smooth ramped step, even mid-stream) and restored when the display
+ * sleeps. Coupling is one-directional: the display side calls in, the
+ * audio path never touches the display. No-op when the protection chain
+ * is disabled.
+ */
+void max98357a_audio_set_display_active(bool active);
+
+/**
  * @brief Set the per-stream digital pre-gain (dB*10, clamped to 0..+120).
  *
  * Applied at the head of the protection chain; the limiter sidechain sees

--- a/drivers/audio/max98357a/include/max98357a_audio.h
+++ b/drivers/audio/max98357a/include/max98357a_audio.h
@@ -115,6 +115,7 @@ struct max98357a_protect_tuning {
 	int release_ms;     /**< -1 = Kconfig default */
 	int ramp_ms;        /**< -1 = Kconfig default */
 	int bass_percent;   /**< psychoacoustic bass drive; -1 = Kconfig default */
+	int peak_percent;   /**< true-peak weighted-drive cap; -1 = Kconfig default */
 	int pregain_db10;   /**< digital pre-gain, dB*10; 0 = unity, max +120 */
 	bool voicing_set;   /**< false = built-in voicing curve */
 	int voicing_db10[6];/**< static voicing gains, dB*10 per band */
@@ -165,12 +166,13 @@ int max98357a_audio_protect_get(const struct device *dev,
  * @param frames         frames processed
  * @param limited_frames frames spent below unity gain
  * @param peak_out       largest |output sample|
+ * @param peak_capped_frames frames the true-peak clamp engaged
  * @param reset          clear the counters after reading
  */
 int max98357a_audio_protect_stats(const struct device *dev,
 				  int32_t *min_gain_q15, uint32_t *frames,
 				  uint32_t *limited_frames, int32_t *peak_out,
-				  bool reset);
+				  uint32_t *peak_capped_frames, bool reset);
 
 /**
  * @brief Configure MAX98357A audio stream

--- a/drivers/audio/max98357a/include/max98357a_audio.h
+++ b/drivers/audio/max98357a/include/max98357a_audio.h
@@ -122,6 +122,21 @@ struct max98357a_protect_tuning {
 	int weights_x100[6];/**< limiter current weights * 100 per band */
 };
 
+/**
+ * @brief Set the per-stream digital pre-gain (dB*10, clamped to 0..+120).
+ *
+ * Applied at the head of the protection chain; the limiter sidechain sees
+ * the boosted signal, so the current budget still caps real transducer
+ * drive (on hot sources the limiter rides the boost out - this is
+ * compression, intended to lift quiet sources such as un-normalized TTS).
+ *
+ * Transient by convention: the halo audio_stream layer clears it to 0 on
+ * every speaker acquisition, so it applies to one playback session only.
+ * Composes additively with the bench-tuning override's pregain. No-op when
+ * the protection chain is disabled.
+ */
+void max98357a_audio_set_stream_pregain(int gain_db10);
+
 /** @brief Apply protection-chain overrides (see struct docs). */
 int max98357a_audio_protect_tune(const struct device *dev,
 				 const struct max98357a_protect_tuning *tuning);

--- a/drivers/audio/max98357a/include/max98357a_audio.h
+++ b/drivers/audio/max98357a/include/max98357a_audio.h
@@ -98,6 +98,53 @@ void max98357a_audio_tx_diag_get(struct max98357a_audio_tx_diag *out);
 void max98357a_audio_tx_diag_zero(void);
 
 /**
+ * @brief Runtime overrides for the current-protection chain (bench tuning).
+ *
+ * Available when CONFIG_MAX98357A_AUDIO_PROTECT_TUNING is enabled. A tune
+ * call REPLACES the whole override set: scalar fields at -1 (and unset
+ * voicing/weights) fall back to their Kconfig/built-in defaults, so an
+ * empty struct (scalars -1, flags false, pregain 0) restores stock
+ * behaviour. Overrides take effect immediately when the stream is stopped,
+ * otherwise at the next stream start.
+ */
+struct max98357a_protect_tuning {
+	int hpf_hz;         /**< -1 = Kconfig default */
+	int budget_percent; /**< -1 = Kconfig default */
+	int env_ms;         /**< -1 = Kconfig default */
+	int hold_ms;        /**< -1 = Kconfig default */
+	int release_ms;     /**< -1 = Kconfig default */
+	int ramp_ms;        /**< -1 = Kconfig default */
+	int bass_percent;   /**< psychoacoustic bass drive; -1 = Kconfig default */
+	int pregain_db10;   /**< digital pre-gain, dB*10; 0 = unity, max +120 */
+	bool voicing_set;   /**< false = built-in voicing curve */
+	int voicing_db10[6];/**< static voicing gains, dB*10 per band */
+	bool weights_set;   /**< false = built-in current weights */
+	int weights_x100[6];/**< limiter current weights * 100 per band */
+};
+
+/** @brief Apply protection-chain overrides (see struct docs). */
+int max98357a_audio_protect_tune(const struct device *dev,
+				 const struct max98357a_protect_tuning *tuning);
+
+/** @brief Read back the stored overrides, scalars resolved to effective values. */
+int max98357a_audio_protect_get(const struct device *dev,
+				struct max98357a_protect_tuning *out);
+
+/**
+ * @brief Read limiter activity since the last reset.
+ *
+ * @param min_gain_q15   lowest limiter gain seen (32768 = never limited)
+ * @param frames         frames processed
+ * @param limited_frames frames spent below unity gain
+ * @param peak_out       largest |output sample|
+ * @param reset          clear the counters after reading
+ */
+int max98357a_audio_protect_stats(const struct device *dev,
+				  int32_t *min_gain_q15, uint32_t *frames,
+				  uint32_t *limited_frames, int32_t *peak_out,
+				  bool reset);
+
+/**
  * @brief Configure MAX98357A audio stream
  *
  * @param dev MAX98357A device

--- a/drivers/audio/max98357a/max98357a_audio.c
+++ b/drivers/audio/max98357a/max98357a_audio.c
@@ -79,6 +79,19 @@ static max98357a_audio_tx_tap_t g_tx_tap;
  * speaker acquisition so it cannot leak into the next owner's stream.
  */
 static int g_stream_pregain_db10;
+
+/* Display power state (display-aware budget ducking). Tracked here so the
+ * chain can be rebuilt at any time (stream reconfiguration) without asking
+ * the display; the display side pushes changes via
+ * max98357a_audio_set_display_active().
+ */
+static bool g_display_active;
+
+static inline int display_budget_drop(void)
+{
+	return g_display_active ?
+	       CONFIG_MAX98357A_AUDIO_PROTECT_DISPLAY_BUDGET_DROP : 0;
+}
 #endif
 
 /* TX-path diagnostic counters (see max98357a_audio.h): every way the tap
@@ -237,6 +250,8 @@ static void max98357a_protect_init(struct max98357a_audio_data *data)
 	data->tune_dirty = false;
 #endif
 
+	spk_protect_set_budget_drop(&data->prot, display_budget_drop());
+
 	/* Total pre-gain = per-stream gain + bench-tuning override (if any) */
 	{
 		int pregain_db10 = g_stream_pregain_db10;
@@ -251,6 +266,21 @@ static void max98357a_protect_init(struct max98357a_audio_data *data)
 	}
 }
 #endif
+
+void max98357a_audio_set_display_active(bool active)
+{
+#if IS_ENABLED(CONFIG_MAX98357A_AUDIO_PROTECTION_EQ)
+	g_display_active = active;
+
+	struct max98357a_audio_data *data = g_amp_data;
+
+	if (data && data->prot_ready) {
+		spk_protect_set_budget_drop(&data->prot, display_budget_drop());
+	}
+#else
+	ARG_UNUSED(active);
+#endif
+}
 
 void max98357a_audio_set_stream_pregain(int gain_db10)
 {

--- a/drivers/audio/max98357a/max98357a_audio.c
+++ b/drivers/audio/max98357a/max98357a_audio.c
@@ -73,6 +73,14 @@ static struct max98357a_audio_data *g_amp_data; /* single instance pointer */
 /* Single-slot TX tap (AEC reference feed); see max98357a_audio.h */
 static max98357a_audio_tx_tap_t g_tx_tap;
 
+#if IS_ENABLED(CONFIG_MAX98357A_AUDIO_PROTECTION_EQ)
+/* Per-stream digital pre-gain (dB*10, 0 = unity). Set by the stream layer
+ * for one playback session; the halo audio_stream layer clears it on every
+ * speaker acquisition so it cannot leak into the next owner's stream.
+ */
+static int g_stream_pregain_db10;
+#endif
+
 /* TX-path diagnostic counters (see max98357a_audio.h): every way the tap
  * feed could diverge from real emission is counted, so a reference-
  * timeline slip can be attributed from session data.
@@ -226,14 +234,53 @@ static void max98357a_protect_init(struct max98357a_audio_data *data)
 		}
 		spk_protect_set_weights(&data->prot, weights);
 	}
-	if (data->tune.pregain_db10 != 0) {
-		spk_protect_set_pregain(&data->prot,
-					spk_protect_db10_to_q15(data->tune.pregain_db10));
-	}
 	data->tune_dirty = false;
 #endif
+
+	/* Total pre-gain = per-stream gain + bench-tuning override (if any) */
+	{
+		int pregain_db10 = g_stream_pregain_db10;
+
+#if IS_ENABLED(CONFIG_MAX98357A_AUDIO_PROTECT_TUNING)
+		pregain_db10 += data->tune.pregain_db10;
+#endif
+		if (pregain_db10 != 0) {
+			spk_protect_set_pregain(&data->prot,
+						spk_protect_db10_to_q15(pregain_db10));
+		}
+	}
 }
 #endif
+
+void max98357a_audio_set_stream_pregain(int gain_db10)
+{
+#if IS_ENABLED(CONFIG_MAX98357A_AUDIO_PROTECTION_EQ)
+	if (gain_db10 < 0) {
+		gain_db10 = 0;
+	}
+	if (gain_db10 > 120) {
+		gain_db10 = 120;
+	}
+	g_stream_pregain_db10 = gain_db10;
+
+	/* Apply to the live chain too: the stream layer sets the gain after
+	 * the stream has been configured (which rebuilt the chain at unity).
+	 */
+	struct max98357a_audio_data *data = g_amp_data;
+
+	if (data && data->prot_ready) {
+		int total = gain_db10;
+
+#if IS_ENABLED(CONFIG_MAX98357A_AUDIO_PROTECT_TUNING)
+		total += data->tune.pregain_db10;
+#endif
+		spk_protect_set_pregain(&data->prot,
+					spk_protect_db10_to_q15(total));
+	}
+#else
+	ARG_UNUSED(gain_db10);
+#endif
+}
 
 #if IS_ENABLED(CONFIG_MAX98357A_AUDIO_PROTECT_TUNING)
 int max98357a_audio_protect_tune(const struct device *dev,

--- a/drivers/audio/max98357a/max98357a_audio.c
+++ b/drivers/audio/max98357a/max98357a_audio.c
@@ -42,6 +42,10 @@ struct max98357a_audio_data {
 #if IS_ENABLED(CONFIG_MAX98357A_AUDIO_PROTECTION_EQ)
 	struct spk_protect prot;                   /* current-protection DSP chain */
 	bool prot_ready;                           /* init succeeded for current config */
+#if IS_ENABLED(CONFIG_MAX98357A_AUDIO_PROTECT_TUNING)
+	struct max98357a_protect_tuning tune;      /* runtime overrides */
+	bool tune_dirty;                           /* apply at next stream start */
+#endif
 #endif
 };
 
@@ -163,6 +167,14 @@ static struct max98357a_block_ctx queue_pop(void) {
 	return ctx;
 }
 
+#if IS_ENABLED(CONFIG_MAX98357A_AUDIO_PROTECT_TUNING)
+/* Scalar override helper: -1 = keep the Kconfig default. */
+static inline int tune_or(int override, int fallback)
+{
+	return (override >= 0) ? override : fallback;
+}
+#endif
+
 #if IS_ENABLED(CONFIG_MAX98357A_AUDIO_PROTECTION_EQ)
 static void max98357a_protect_init(struct max98357a_audio_data *data)
 {
@@ -175,16 +187,135 @@ static void max98357a_protect_init(struct max98357a_audio_data *data)
 		.hold_ms = CONFIG_MAX98357A_AUDIO_PROTECT_HOLD_MS,
 		.release_ms = CONFIG_MAX98357A_AUDIO_PROTECT_RELEASE_MS,
 		.ramp_ms = CONFIG_MAX98357A_AUDIO_PROTECT_RAMP_MS,
+		.bass_drive_percent = CONFIG_MAX98357A_AUDIO_BASS_ENHANCE_PERCENT,
 	};
+
+#if IS_ENABLED(CONFIG_MAX98357A_AUDIO_PROTECT_TUNING)
+	params.hpf_cutoff_hz = tune_or(data->tune.hpf_hz, params.hpf_cutoff_hz);
+	params.budget_percent = tune_or(data->tune.budget_percent, params.budget_percent);
+	params.env_ms = tune_or(data->tune.env_ms, params.env_ms);
+	params.hold_ms = tune_or(data->tune.hold_ms, params.hold_ms);
+	params.release_ms = tune_or(data->tune.release_ms, params.release_ms);
+	params.ramp_ms = tune_or(data->tune.ramp_ms, params.ramp_ms);
+	params.bass_drive_percent =
+		tune_or(data->tune.bass_percent, params.bass_drive_percent);
+#endif
 
 	data->prot_ready = (spk_protect_init(&data->prot, &params) == 0);
 	if (!data->prot_ready) {
 		LOG_ERR("speaker protection init failed (rate %u ch %d) - "
 			"audio will play unprotected",
 			data->config.sample_rate, params.channels);
+		return;
 	}
+
+#if IS_ENABLED(CONFIG_MAX98357A_AUDIO_PROTECT_TUNING)
+	if (data->tune.voicing_set) {
+		int32_t gains[SPK_PROTECT_BANDS];
+
+		for (int i = 0; i < SPK_PROTECT_BANDS; i++) {
+			gains[i] = spk_protect_db10_to_q15(data->tune.voicing_db10[i]);
+		}
+		spk_protect_set_voicing(&data->prot, gains);
+	}
+	if (data->tune.weights_set) {
+		int32_t weights[SPK_PROTECT_BANDS];
+
+		for (int i = 0; i < SPK_PROTECT_BANDS; i++) {
+			weights[i] = (int32_t)(((int64_t)data->tune.weights_x100[i] * 4096) / 100);
+		}
+		spk_protect_set_weights(&data->prot, weights);
+	}
+	if (data->tune.pregain_db10 != 0) {
+		spk_protect_set_pregain(&data->prot,
+					spk_protect_db10_to_q15(data->tune.pregain_db10));
+	}
+	data->tune_dirty = false;
+#endif
 }
 #endif
+
+#if IS_ENABLED(CONFIG_MAX98357A_AUDIO_PROTECT_TUNING)
+int max98357a_audio_protect_tune(const struct device *dev,
+				 const struct max98357a_protect_tuning *tuning)
+{
+	struct max98357a_audio_data *data = dev->data;
+
+	if (!tuning) {
+		return -EINVAL;
+	}
+	if (tuning->pregain_db10 < -600 || tuning->pregain_db10 > 120) {
+		return -EINVAL;
+	}
+	if (tuning->budget_percent > 100 ||
+	    (tuning->budget_percent == 0)) {
+		return -EINVAL;
+	}
+
+	data->tune = *tuning;
+
+	/* Streams re-init the chain at START; when idle (or never
+	 * configured) apply immediately so the next play uses it even if
+	 * the stream config is unchanged.
+	 */
+	if (data->configured && data->state != MAX98357A_AUDIO_TRIGGER_START) {
+		max98357a_protect_init(data);
+	} else {
+		data->tune_dirty = true;
+	}
+
+	return 0;
+}
+
+int max98357a_audio_protect_get(const struct device *dev,
+				struct max98357a_protect_tuning *out)
+{
+	struct max98357a_audio_data *data = dev->data;
+
+	if (!out) {
+		return -EINVAL;
+	}
+	*out = data->tune;
+	out->hpf_hz = tune_or(out->hpf_hz, CONFIG_MAX98357A_AUDIO_PROTECT_HPF_HZ);
+	out->budget_percent =
+		tune_or(out->budget_percent, CONFIG_MAX98357A_AUDIO_PROTECT_BUDGET_PERCENT);
+	out->env_ms = tune_or(out->env_ms, CONFIG_MAX98357A_AUDIO_PROTECT_ENV_MS);
+	out->hold_ms = tune_or(out->hold_ms, CONFIG_MAX98357A_AUDIO_PROTECT_HOLD_MS);
+	out->release_ms =
+		tune_or(out->release_ms, CONFIG_MAX98357A_AUDIO_PROTECT_RELEASE_MS);
+	out->ramp_ms = tune_or(out->ramp_ms, CONFIG_MAX98357A_AUDIO_PROTECT_RAMP_MS);
+	out->bass_percent =
+		tune_or(out->bass_percent, CONFIG_MAX98357A_AUDIO_BASS_ENHANCE_PERCENT);
+	return 0;
+}
+
+int max98357a_audio_protect_stats(const struct device *dev,
+				  int32_t *min_gain_q15, uint32_t *frames,
+				  uint32_t *limited_frames, int32_t *peak_out,
+				  bool reset)
+{
+	struct max98357a_audio_data *data = dev->data;
+	struct spk_protect_stats stats;
+
+	if (!data->prot_ready) {
+		return -ENODEV;
+	}
+	spk_protect_stats_read(&data->prot, &stats, reset);
+	if (min_gain_q15) {
+		*min_gain_q15 = stats.min_gain_q15;
+	}
+	if (frames) {
+		*frames = stats.frames;
+	}
+	if (limited_frames) {
+		*limited_frames = stats.limited_frames;
+	}
+	if (peak_out) {
+		*peak_out = stats.peak_out;
+	}
+	return 0;
+}
+#endif /* CONFIG_MAX98357A_AUDIO_PROTECT_TUNING */
 
 /* Silence-feed block: while a session is open (START) and an AEC tap is
  * registered, a drained queue is fed this zero block instead of letting
@@ -334,6 +465,14 @@ static int max98357a_audio_trigger_impl(const struct device *dev,
 		if (cfg->sd_mode_gpio.port) {
 			gpio_pin_set_dt(&cfg->sd_mode_gpio, 1);
 		}
+#if IS_ENABLED(CONFIG_MAX98357A_AUDIO_PROTECT_TUNING)
+		/* Overrides changed while a stream was active: rebuild the
+		 * chain now, before playback begins.
+		 */
+		if (data->tune_dirty) {
+			max98357a_protect_init(data);
+		}
+#endif
 #if IS_ENABLED(CONFIG_MAX98357A_AUDIO_PROTECTION_EQ)
 		/* Clear filter state (no stale transient) and restart the
 		 * onset ramp to spread turn-on inrush current.
@@ -665,6 +804,18 @@ static int max98357a_audio_init(const struct device *dev)
 	atomic_set(&data->bytes_queued, 0);
 #if IS_ENABLED(CONFIG_MAX98357A_AUDIO_PROTECTION_EQ)
 	data->prot_ready = false; /* initialised on first configure */
+#if IS_ENABLED(CONFIG_MAX98357A_AUDIO_PROTECT_TUNING)
+	/* No overrides at boot: scalars at -1 mean "Kconfig default" (a
+	 * zeroed struct would read as hpf_hz=0 = HPF disabled).
+	 */
+	data->tune.hpf_hz = -1;
+	data->tune.budget_percent = -1;
+	data->tune.env_ms = -1;
+	data->tune.hold_ms = -1;
+	data->tune.release_ms = -1;
+	data->tune.ramp_ms = -1;
+	data->tune.bass_percent = -1;
+#endif
 #endif
 
 	LOG_INF("MAX98357A audio driver (sync) initialized; block %d x %d", MAX98357A_AUDIO_TX_BLOCK_SIZE, MAX98357A_AUDIO_TX_BLOCK_COUNT);

--- a/drivers/audio/max98357a/max98357a_audio.c
+++ b/drivers/audio/max98357a/max98357a_audio.c
@@ -80,6 +80,13 @@ static max98357a_audio_tx_tap_t g_tx_tap;
  */
 static int g_stream_pregain_db10;
 
+/* Per-stream budget override (0 = none). Any override also selects the
+ * fast integration window - that is what makes raised budgets safe.
+ * Transient like the pre-gain: the halo audio_stream layer clears it on
+ * every speaker acquisition.
+ */
+static int g_stream_budget;
+
 /* Display power state (display-aware budget ducking). Tracked here so the
  * chain can be rebuilt at any time (stream reconfiguration) without asking
  * the display; the display side pushes changes via
@@ -212,6 +219,12 @@ static void max98357a_protect_init(struct max98357a_audio_data *data)
 		.peak_cap_percent = CONFIG_MAX98357A_AUDIO_PROTECT_PEAK_CAP_PERCENT,
 	};
 
+	if (g_stream_budget > 0) {
+		params.budget_percent = g_stream_budget;
+		params.env_ms =
+			CONFIG_MAX98357A_AUDIO_PROTECT_STREAM_BUDGET_ENV_MS;
+	}
+
 #if IS_ENABLED(CONFIG_MAX98357A_AUDIO_PROTECT_TUNING)
 	params.hpf_cutoff_hz = tune_or(data->tune.hpf_hz, params.hpf_cutoff_hz);
 	params.budget_percent = tune_or(data->tune.budget_percent, params.budget_percent);
@@ -282,6 +295,40 @@ void max98357a_audio_set_display_active(bool active)
 	}
 #else
 	ARG_UNUSED(active);
+#endif
+}
+
+void max98357a_audio_set_stream_budget(int budget_percent)
+{
+#if IS_ENABLED(CONFIG_MAX98357A_AUDIO_PROTECTION_EQ)
+	if (budget_percent < 0) {
+		budget_percent = 0;
+	}
+	if (budget_percent > 0 && budget_percent < 10) {
+		budget_percent = 10;
+	}
+	if (budget_percent > CONFIG_MAX98357A_AUDIO_PROTECT_STREAM_BUDGET_MAX) {
+		budget_percent = CONFIG_MAX98357A_AUDIO_PROTECT_STREAM_BUDGET_MAX;
+	}
+	if (g_stream_budget == budget_percent) {
+		return;
+	}
+	g_stream_budget = budget_percent;
+
+	/* Budget and integration window live in precomputed chain state:
+	 * rebuild when idle (the stream layer sets the override between
+	 * configure and start). While a stream is running the change
+	 * applies at its next (re)configure - the override is chosen at
+	 * stream start by design.
+	 */
+	struct max98357a_audio_data *data = g_amp_data;
+
+	if (data && data->configured &&
+	    data->state != MAX98357A_AUDIO_TRIGGER_START) {
+		max98357a_protect_init(data);
+	}
+#else
+	ARG_UNUSED(budget_percent);
 #endif
 }
 

--- a/drivers/audio/max98357a/max98357a_audio.c
+++ b/drivers/audio/max98357a/max98357a_audio.c
@@ -209,6 +209,7 @@ static void max98357a_protect_init(struct max98357a_audio_data *data)
 		.release_ms = CONFIG_MAX98357A_AUDIO_PROTECT_RELEASE_MS,
 		.ramp_ms = CONFIG_MAX98357A_AUDIO_PROTECT_RAMP_MS,
 		.bass_drive_percent = CONFIG_MAX98357A_AUDIO_BASS_ENHANCE_PERCENT,
+		.peak_cap_percent = CONFIG_MAX98357A_AUDIO_PROTECT_PEAK_CAP_PERCENT,
 	};
 
 #if IS_ENABLED(CONFIG_MAX98357A_AUDIO_PROTECT_TUNING)
@@ -220,6 +221,8 @@ static void max98357a_protect_init(struct max98357a_audio_data *data)
 	params.ramp_ms = tune_or(data->tune.ramp_ms, params.ramp_ms);
 	params.bass_drive_percent =
 		tune_or(data->tune.bass_percent, params.bass_drive_percent);
+	params.peak_cap_percent =
+		tune_or(data->tune.peak_percent, params.peak_cap_percent);
 #endif
 
 	data->prot_ready = (spk_protect_init(&data->prot, &params) == 0);
@@ -363,13 +366,16 @@ int max98357a_audio_protect_get(const struct device *dev,
 	out->ramp_ms = tune_or(out->ramp_ms, CONFIG_MAX98357A_AUDIO_PROTECT_RAMP_MS);
 	out->bass_percent =
 		tune_or(out->bass_percent, CONFIG_MAX98357A_AUDIO_BASS_ENHANCE_PERCENT);
+	out->peak_percent =
+		tune_or(out->peak_percent,
+			CONFIG_MAX98357A_AUDIO_PROTECT_PEAK_CAP_PERCENT);
 	return 0;
 }
 
 int max98357a_audio_protect_stats(const struct device *dev,
 				  int32_t *min_gain_q15, uint32_t *frames,
 				  uint32_t *limited_frames, int32_t *peak_out,
-				  bool reset)
+				  uint32_t *peak_capped_frames, bool reset)
 {
 	struct max98357a_audio_data *data = dev->data;
 	struct spk_protect_stats stats;
@@ -378,6 +384,9 @@ int max98357a_audio_protect_stats(const struct device *dev,
 		return -ENODEV;
 	}
 	spk_protect_stats_read(&data->prot, &stats, reset);
+	if (peak_capped_frames) {
+		*peak_capped_frames = stats.peak_capped_frames;
+	}
 	if (min_gain_q15) {
 		*min_gain_q15 = stats.min_gain_q15;
 	}
@@ -892,6 +901,7 @@ static int max98357a_audio_init(const struct device *dev)
 	data->tune.release_ms = -1;
 	data->tune.ramp_ms = -1;
 	data->tune.bass_percent = -1;
+	data->tune.peak_percent = -1;
 #endif
 #endif
 

--- a/drivers/audio/max98357a/speaker_protect.c
+++ b/drivers/audio/max98357a/speaker_protect.c
@@ -152,6 +152,22 @@ static int64_t isqrt64(int64_t val)
 	return (int64_t)(root >> 1);
 }
 
+/** Envelope threshold for a budget percentage (see file header). */
+static int64_t threshold_env_for(int budget_percent)
+{
+	int64_t amp = (32767LL * budget_percent) / 100;
+
+	return (amp * amp) / 2;
+}
+
+/** Budget after the runtime drop, floored so audio never fully mutes. */
+static int effective_budget(const struct spk_protect *sp)
+{
+	int budget = sp->params.budget_percent - sp->budget_drop_applied;
+
+	return (budget < 5) ? 5 : budget;
+}
+
 int spk_protect_init(struct spk_protect *sp, const struct spk_protect_params *params)
 {
 	if (!sp || !params) {
@@ -242,11 +258,8 @@ int spk_protect_init(struct spk_protect *sp, const struct spk_protect_params *pa
 	/* Budget: steady-state envelope of a reference-band (weight 1.0)
 	 * sine of amplitude budget_percent * FS is A^2 / 2.
 	 */
-	{
-		int64_t amp = (32767LL * params->budget_percent) / 100;
-
-		sp->threshold_env = (amp * amp) / 2;
-	}
+	sp->threshold_env = threshold_env_for(params->budget_percent);
+	sp->threshold_target = sp->threshold_env;
 
 	sp->hold_samples = (int32_t)((int64_t)params->sample_rate *
 				     params->hold_ms / 1000);
@@ -284,6 +297,10 @@ void spk_protect_reset(struct spk_protect *sp)
 	sp->gain_q15 = Q15_ONE;
 	sp->hold_left = 0;
 	sp->ramp_q15 = (sp->params.ramp_ms > 0) ? 0 : Q15_ONE;
+	/* A (re)started stream fades in from silence anyway: land any
+	 * pending budget slew instead of carrying it across streams.
+	 */
+	sp->threshold_env = sp->threshold_target;
 	/* stats deliberately survive stream restarts; they clear on init or
 	 * an explicit spk_protect_stats_read(reset=true).
 	 */
@@ -324,6 +341,23 @@ void spk_protect_set_pregain(struct spk_protect *sp, int32_t pregain_q15)
 		pregain_q15 = 4 * Q15_ONE;
 	}
 	sp->pregain_q15 = pregain_q15;
+}
+
+void spk_protect_set_budget_drop(struct spk_protect *sp, int drop_percent)
+{
+	if (!sp) {
+		return;
+	}
+	if (drop_percent < 0) {
+		drop_percent = 0;
+	}
+	if (drop_percent > 95) {
+		drop_percent = 95;
+	}
+	/* Single aligned int32 store; the process loop picks it up per
+	 * frame and slews the threshold (see spk_protect_process).
+	 */
+	sp->budget_drop_req = drop_percent;
 }
 
 int32_t spk_protect_db10_to_q15(int db10)
@@ -527,6 +561,36 @@ void spk_protect_process(struct spk_protect *sp, int16_t *pcm, size_t num_sample
 			frame_proxy += (p < 0) ? -p : p;
 		}
 
+		/* --- Budget slew (display-aware ducking), once per frame --- */
+		if (sp->budget_drop_req != sp->budget_drop_applied) {
+			sp->budget_drop_applied = sp->budget_drop_req;
+			sp->threshold_target =
+				threshold_env_for(effective_budget(sp));
+			if (sp->ramp_q15 < Q15_ONE) {
+				/* stream still fading in: land it now */
+				sp->threshold_env = sp->threshold_target;
+			} else {
+				int32_t frames = Q15_ONE / sp->ramp_step;
+				int64_t delta = sp->threshold_target -
+						sp->threshold_env;
+				int64_t step = delta / (frames > 0 ? frames : 1);
+
+				if (step == 0) {
+					step = (delta > 0) ? 1 : -1;
+				}
+				sp->threshold_step = step;
+			}
+		}
+		if (sp->threshold_env != sp->threshold_target) {
+			sp->threshold_env += sp->threshold_step;
+			if ((sp->threshold_step > 0 &&
+			     sp->threshold_env > sp->threshold_target) ||
+			    (sp->threshold_step < 0 &&
+			     sp->threshold_env < sp->threshold_target)) {
+				sp->threshold_env = sp->threshold_target;
+			}
+		}
+
 		/* --- Sidechain + gain update, once per frame --- */
 		sp->env += (frame_proxy * frame_proxy - sp->env) >> sp->env_shift;
 
@@ -537,6 +601,21 @@ void spk_protect_process(struct spk_protect *sp, int16_t *pcm, size_t num_sample
 
 			if (target < sp->gain_q15) {
 				sp->gain_q15 = target;   /* instant attack */
+			} else if (sp->gain_q15 < target) {
+				/* Clamped harder than the current threshold
+				 * requires - happens when the budget is raised
+				 * mid-clamp (display back to power save).
+				 * Release toward the exact safe clamp; without
+				 * this the gain would ratchet down for as long
+				 * as the content stays over budget.
+				 */
+				int32_t step = (target - sp->gain_q15) >>
+					       sp->release_shift;
+
+				sp->gain_q15 += (step > 0) ? step : 1;
+				if (sp->gain_q15 > target) {
+					sp->gain_q15 = target;
+				}
 			}
 			sp->hold_left = sp->hold_samples;
 		} else if (sp->hold_left > 0) {

--- a/drivers/audio/max98357a/speaker_protect.c
+++ b/drivers/audio/max98357a/speaker_protect.c
@@ -193,6 +193,9 @@ int spk_protect_init(struct spk_protect *sp, const struct spk_protect_params *pa
 	if (params->bass_drive_percent < 0 || params->bass_drive_percent > 200) {
 		return -1;
 	}
+	if (params->peak_cap_percent < 0 || params->peak_cap_percent > 1000) {
+		return -1;
+	}
 
 	memset(sp, 0, sizeof(*sp));
 	sp->params = *params;
@@ -282,6 +285,16 @@ int spk_protect_init(struct spk_protect *sp, const struct spk_protect_params *pa
 		sp->ramp_step = Q15_ONE;
 	}
 
+	/* --- True-peak current clamp: cap in weighted proxy units
+	 * (sample domain x weight, like frame_proxy); ~4 ms release.
+	 */
+	sp->peak_cap = (32767LL * params->peak_cap_percent) / 100;
+	sp->peak_release_shift = ilog2_i32(
+		(int32_t)((int64_t)params->sample_rate * 4 / 1000));
+	if (sp->peak_release_shift < 1) {
+		sp->peak_release_shift = 1;
+	}
+
 	spk_protect_reset(sp);
 	return 0;
 }
@@ -297,6 +310,7 @@ void spk_protect_reset(struct spk_protect *sp)
 	sp->gain_q15 = Q15_ONE;
 	sp->hold_left = 0;
 	sp->ramp_q15 = (sp->params.ramp_ms > 0) ? 0 : Q15_ONE;
+	sp->peak_gain_q15 = Q15_ONE;
 	/* A (re)started stream fades in from silence anyway: land any
 	 * pending budget slew instead of carrying it across streams.
 	 */
@@ -382,6 +396,7 @@ void spk_protect_stats_read(struct spk_protect *sp,
 		sp->stats.frames = 0;
 		sp->stats.limited_frames = 0;
 		sp->stats.peak_out = 0;
+		sp->stats.peak_capped_frames = 0;
 	}
 }
 
@@ -634,6 +649,39 @@ void spk_protect_process(struct spk_protect *sp, int16_t *pcm, size_t num_sample
 			}
 		}
 
+		/* --- True-peak current clamp, once per frame ---
+		 * The energy sidechain needs ~env_ms to see a transient, but
+		 * the battery IC's short-circuit comparator reacts in
+		 * hundreds of microseconds - a pregain-boosted fricative
+		 * onset can latch it inside that blind window (observed on
+		 * hardware). Cap the post-gain instantaneous weighted drive
+		 * immediately: instant attack, ~4 ms release. The estimate
+		 * uses the broadband gain; the LF duck only cuts further, so
+		 * it is conservative.
+		 */
+		if (sp->peak_cap > 0) {
+			int64_t out_est = (frame_proxy * sp->gain_q15) >> 15;
+			int32_t pt = Q15_ONE;
+
+			if (out_est > sp->peak_cap) {
+				pt = (int32_t)((sp->peak_cap << 15) / out_est);
+			}
+			if (pt < sp->peak_gain_q15) {
+				sp->peak_gain_q15 = pt;  /* instant attack */
+			} else if (sp->peak_gain_q15 < pt) {
+				int32_t step = (pt - sp->peak_gain_q15) >>
+					       sp->peak_release_shift;
+
+				sp->peak_gain_q15 += (step > 0) ? step : 1;
+				if (sp->peak_gain_q15 > pt) {
+					sp->peak_gain_q15 = pt;
+				}
+			}
+			if (sp->peak_gain_q15 < Q15_ONE) {
+				sp->stats.peak_capped_frames++;
+			}
+		}
+
 		/* --- Recombine with LF-first ducking, write frame out --- */
 		int32_t g = sp->gain_q15;
 		int32_t g2 = (int32_t)(((int64_t)g * g) >> 15);
@@ -642,6 +690,9 @@ void spk_protect_process(struct spk_protect *sp, int16_t *pcm, size_t num_sample
 			int64_t y = ((y_lf[c] * g2) >> 15) + y_hf[c];
 
 			y = (y * g) >> 15;      /* broadband gain */
+			if (sp->peak_gain_q15 < Q15_ONE) {
+				y = (y * sp->peak_gain_q15) >> 15;
+			}
 			y >>= 15;               /* Q15-extended -> samples */
 
 			/* Soft-knee clipper, +/-90 % FS knee, 1/4 slope */

--- a/drivers/audio/max98357a/speaker_protect.c
+++ b/drivers/audio/max98357a/speaker_protect.c
@@ -80,6 +80,22 @@ static const int32_t current_weight_q12[SPK_PROTECT_BANDS] = {
 #define SOFT_CLIP_KNEE  29491
 #define SOFT_CLIP_SHIFT 2
 
+/* Psychoacoustic bass enhancer corner frequencies.
+ *
+ * Source band 60-240 Hz covers the current-hungry region the HPF/EQ removes
+ * (and the TTS voice fundamentals). Full-wave rectification of that band
+ * generates even harmonics (2f, 4f, ...); the 180 Hz high-pass strips the
+ * rectifier's DC and fundamental residue and the 900 Hz low-pass keeps only
+ * the 2nd-4th harmonics, which land in the transducer's efficient region.
+ * The ear reconstructs the missing fundamental from the harmonic series
+ * (the "missing fundamental" effect), so the voice is perceived as full
+ * without the transducer being driven at the frequencies that draw current.
+ */
+#define BASS_SRC_LO_HZ   60
+#define BASS_SRC_HI_HZ   240
+#define BASS_HARM_LO_HZ  180
+#define BASS_HARM_HI_HZ  900
+
 static inline int16_t sat_i16(int32_t v)
 {
 	if (v > INT16_MAX) {
@@ -101,6 +117,14 @@ static int32_t ilog2_i32(int32_t v)
 		r++;
 	}
 	return r;
+}
+
+static int32_t one_pole_alpha_q15(int sample_rate, int freq_hz)
+{
+	double omega = 2.0 * M_PI * (double)freq_hz;
+
+	return (int32_t)((double)Q15_ONE * omega /
+			 ((double)sample_rate + omega) + 0.5);
 }
 
 /** Integer sqrt of a non-negative int64, result <= 2^31 - 1. */
@@ -144,9 +168,16 @@ int spk_protect_init(struct spk_protect *sp, const struct spk_protect_params *pa
 	    params->release_ms < 1 || params->ramp_ms < 0) {
 		return -1;
 	}
+	if (params->bass_drive_percent < 0 || params->bass_drive_percent > 200) {
+		return -1;
+	}
 
 	memset(sp, 0, sizeof(*sp));
 	sp->params = *params;
+
+	memcpy(sp->voicing_q15, static_gain_q15, sizeof(sp->voicing_q15));
+	memcpy(sp->weight_q12, current_weight_q12, sizeof(sp->weight_q12));
+	sp->pregain_q15 = Q15_ONE;
 
 	/* --- HPF: 2nd-order Butterworth (Q = 1/sqrt(2)), bilinear transform.
 	 * Double math at init only; the hot path is pure fixed point.
@@ -174,6 +205,21 @@ int spk_protect_init(struct spk_protect *sp, const struct spk_protect_params *pa
 
 		sp->alpha_q15[i] = (int32_t)((double)Q15_ONE * omega /
 					     ((double)params->sample_rate + omega) + 0.5);
+	}
+
+	/* --- Psychoacoustic bass enhancer --- */
+	if (params->bass_drive_percent > 0) {
+		sp->bass_enabled = true;
+		sp->bass_drive_q15 = (int32_t)(((int64_t)Q15_ONE *
+						params->bass_drive_percent) / 100);
+		sp->bass_alpha_lo = one_pole_alpha_q15(params->sample_rate,
+						       BASS_SRC_LO_HZ);
+		sp->bass_alpha_hi = one_pole_alpha_q15(params->sample_rate,
+						       BASS_SRC_HI_HZ);
+		sp->bass_alpha_dc = one_pole_alpha_q15(params->sample_rate,
+						       BASS_HARM_LO_HZ);
+		sp->bass_alpha_out = one_pole_alpha_q15(params->sample_rate,
+							BASS_HARM_HI_HZ);
 	}
 
 	/* --- Limiter sidechain ---
@@ -232,6 +278,128 @@ void spk_protect_reset(struct spk_protect *sp)
 	sp->gain_q15 = Q15_ONE;
 	sp->hold_left = 0;
 	sp->ramp_q15 = (sp->params.ramp_ms > 0) ? 0 : Q15_ONE;
+	/* stats deliberately survive stream restarts; they clear on init or
+	 * an explicit spk_protect_stats_read(reset=true).
+	 */
+	if (sp->stats.min_gain_q15 == 0) {
+		sp->stats.min_gain_q15 = Q15_ONE; /* fresh instance (memset) */
+	}
+}
+
+void spk_protect_set_voicing(struct spk_protect *sp,
+			     const int32_t gains_q15[SPK_PROTECT_BANDS])
+{
+	if (!sp) {
+		return;
+	}
+	memcpy(sp->voicing_q15, gains_q15 ? gains_q15 : static_gain_q15,
+	       sizeof(sp->voicing_q15));
+}
+
+void spk_protect_set_weights(struct spk_protect *sp,
+			     const int32_t weights_q12[SPK_PROTECT_BANDS])
+{
+	if (!sp) {
+		return;
+	}
+	memcpy(sp->weight_q12, weights_q12 ? weights_q12 : current_weight_q12,
+	       sizeof(sp->weight_q12));
+}
+
+void spk_protect_set_pregain(struct spk_protect *sp, int32_t pregain_q15)
+{
+	if (!sp) {
+		return;
+	}
+	if (pregain_q15 < 0) {
+		pregain_q15 = 0;
+	}
+	if (pregain_q15 > 4 * Q15_ONE) {
+		pregain_q15 = 4 * Q15_ONE;
+	}
+	sp->pregain_q15 = pregain_q15;
+}
+
+int32_t spk_protect_db10_to_q15(int db10)
+{
+	double lin = pow(10.0, (double)db10 / 200.0) * (double)Q15_ONE;
+
+	if (lin > 4.0 * Q15_ONE) {
+		lin = 4.0 * Q15_ONE;
+	}
+	return (int32_t)(lin + 0.5);
+}
+
+void spk_protect_stats_read(struct spk_protect *sp,
+			    struct spk_protect_stats *out, bool reset)
+{
+	if (!sp || !out) {
+		return;
+	}
+	*out = sp->stats;
+	if (reset) {
+		sp->stats.min_gain_q15 = Q15_ONE;
+		sp->stats.frames = 0;
+		sp->stats.limited_frames = 0;
+		sp->stats.peak_out = 0;
+	}
+}
+
+const int32_t *spk_protect_default_voicing(void)
+{
+	return static_gain_q15;
+}
+
+const int32_t *spk_protect_default_weights(void)
+{
+	return current_weight_q12;
+}
+
+/*
+ * Psychoacoustic bass: returns the shaped harmonic signal (sample domain)
+ * to be mixed into the input BEFORE the HPF removes the source band.
+ *
+ * Internally Q15-extended for filter accuracy:
+ *   bass = LP240^2(x) - LP60(x)        (source band; the upper edge is two
+ *                                       cascaded poles, 12 dB/oct, so voice
+ *                                       mids stay out of the rectifier)
+ *   rect = |bass|                      (even harmonics + DC)
+ *   harm = LP900(rect - LP180(rect))   (strip DC/fundamental, cap fizz)
+ *   out  = harm * drive
+ */
+static inline int32_t bass_enhance(const struct spk_protect *sp,
+				   struct spk_protect_channel *ch, int32_t x)
+{
+	int32_t x_q15;
+
+	if (x > 2 * 32767) {
+		x = 2 * 32767;
+	} else if (x < -2 * 32767) {
+		x = -2 * 32767;
+	}
+	x_q15 = x * (1 << 15);
+
+	ch->bass_lp_lo += (int32_t)(((int64_t)sp->bass_alpha_lo *
+				     ((int64_t)x_q15 - ch->bass_lp_lo)) >> 15);
+	ch->bass_lp_hi += (int32_t)(((int64_t)sp->bass_alpha_hi *
+				     ((int64_t)x_q15 - ch->bass_lp_hi)) >> 15);
+	ch->bass_lp_hi2 += (int32_t)(((int64_t)sp->bass_alpha_hi *
+				      ((int64_t)ch->bass_lp_hi - ch->bass_lp_hi2)) >> 15);
+
+	int64_t bass = (int64_t)ch->bass_lp_hi2 - ch->bass_lp_lo;
+	int32_t rect = (int32_t)((bass < 0) ? -bass : bass);
+
+	ch->bass_lp_dc += (int32_t)(((int64_t)sp->bass_alpha_dc *
+				     ((int64_t)rect - ch->bass_lp_dc)) >> 15);
+
+	int32_t harm = rect - ch->bass_lp_dc;
+
+	ch->bass_lp_out += (int32_t)(((int64_t)sp->bass_alpha_out *
+				      ((int64_t)harm - ch->bass_lp_out)) >> 15);
+
+	int64_t out = ((int64_t)ch->bass_lp_out * sp->bass_drive_q15) >> 15;
+
+	return (int32_t)(out >> 15); /* Q15-extended -> sample domain */
 }
 
 /** HPF biquad, Direct Form II Transposed, Q30 coefficients. */
@@ -271,6 +439,22 @@ void spk_protect_process(struct spk_protect *sp, int16_t *pcm, size_t num_sample
 			/* Onset ramp */
 			x = (int32_t)(((int64_t)x * sp->ramp_q15) >> 15);
 
+			/* Digital pre-gain (may exceed unity; the limiter
+			 * sidechain below sees the boosted level, so the
+			 * energy budget still holds).
+			 */
+			if (sp->pregain_q15 != Q15_ONE) {
+				x = (int32_t)(((int64_t)x * sp->pregain_q15) >> 15);
+			}
+
+			/* Harmonics are generated from (and mixed into) the
+			 * pre-HPF signal, so the added energy is itself
+			 * protection-limited by the chain below.
+			 */
+			if (sp->bass_enabled) {
+				x += bass_enhance(sp, ch, x);
+			}
+
 			if (sp->hpf_enabled) {
 				x = hpf_process(sp, ch, x);
 			}
@@ -281,34 +465,37 @@ void spk_protect_process(struct spk_protect *sp, int16_t *pcm, size_t num_sample
 			 */
 			int32_t x_q15;
 
-			if (x > (1 << 16)) { /* headroom guard before *2^15 */
-				x_q15 = INT32_MAX;
-			} else if (x < -(1 << 16)) {
-				x_q15 = INT32_MIN;
-			} else {
-				x_q15 = x * (1 << 15);
+			/* Headroom guard before *2^15: saturate at +/- 2x FS
+			 * (pre-gain and HPF overshoot can exceed int16), so
+			 * x_q15 and the split arithmetic below stay in range.
+			 */
+			if (x > 2 * 32767) {
+				x = 2 * 32767;
+			} else if (x < -2 * 32767) {
+				x = -2 * 32767;
 			}
+			x_q15 = x * (1 << 15);
 
 			int64_t lf = 0, hf = 0, proxy = 0;
 			int32_t prev_lp = 0;
 
 			for (int b = 0; b < SPK_PROTECT_BANDS; b++) {
-				int32_t band;
+				int64_t band;
 
 				if (b < SPK_PROTECT_SPLITS) {
 					int32_t lp = ch->lp[b] +
 						(int32_t)(((int64_t)sp->alpha_q15[b] *
-							   (x_q15 - ch->lp[b])) >> 15);
+							   ((int64_t)x_q15 - ch->lp[b])) >> 15);
 
 					ch->lp[b] = lp;
-					band = lp - prev_lp;
+					band = (int64_t)lp - prev_lp;
 					prev_lp = lp;
 				} else {
-					band = x_q15 - prev_lp;
+					band = (int64_t)x_q15 - prev_lp;
 				}
 
 				/* Post-static-gain band: what is actually driven */
-				int64_t bs = ((int64_t)band * static_gain_q15[b]) >> 15;
+				int64_t bs = (band * sp->voicing_q15[b]) >> 15;
 
 				if (b < LF_DUCK_BANDS) {
 					lf += bs;
@@ -319,7 +506,7 @@ void spk_protect_process(struct spk_protect *sp, int16_t *pcm, size_t num_sample
 				/* Sidechain: post-static-gain, current-weighted,
 				 * so the budget measures real transducer drive.
 				 */
-				proxy += (bs * current_weight_q12[b]) >> 12;
+				proxy += (bs * sp->weight_q12[b]) >> 12;
 			}
 
 			y_lf[c] = lf;
@@ -354,6 +541,14 @@ void spk_protect_process(struct spk_protect *sp, int16_t *pcm, size_t num_sample
 			sp->gain_q15 += (step > 0) ? step : 1;
 		}
 
+		sp->stats.frames++;
+		if (sp->gain_q15 < Q15_ONE) {
+			sp->stats.limited_frames++;
+			if (sp->gain_q15 < sp->stats.min_gain_q15) {
+				sp->stats.min_gain_q15 = sp->gain_q15;
+			}
+		}
+
 		/* --- Recombine with LF-first ducking, write frame out --- */
 		int32_t g = sp->gain_q15;
 		int32_t g2 = (int32_t)(((int64_t)g * g) >> 15);
@@ -374,6 +569,12 @@ void spk_protect_process(struct spk_protect *sp, int16_t *pcm, size_t num_sample
 			}
 
 			pcm[i + c] = sat_i16((int32_t)y);
+
+			int32_t ay = (int32_t)((y < 0) ? -y : y);
+
+			if (ay > sp->stats.peak_out) {
+				sp->stats.peak_out = ay;
+			}
 		}
 
 		/* Advance onset ramp once per frame */

--- a/drivers/audio/max98357a/speaker_protect.c
+++ b/drivers/audio/max98357a/speaker_protect.c
@@ -36,39 +36,45 @@ static const uint16_t split_hz[SPK_PROTECT_SPLITS] = {
 
 /* Static voicing gains per band (Q15).
  *
- * Roughly half (in dB) of the issue #180 protection curve: that curve was
- * tuned as the *only* protection; the energy limiter now carries the
- * protection duty, so the static cut only pre-shapes the response.
+ * Loudness-rebalanced curve: deepen the cuts below the transducer's
+ * efficient region and boost the top band, reallocating the fixed current
+ * budget toward the bands that produce audible loudness instead of felt
+ * vibration. Blinded on-head A/B against the previous half-depth #180
+ * curve: louder at equal buzz, with measured limiter engagement on speech
+ * dropping from ~40 % to ~25 % of frames at full volume.
  *
  *   band       < 150  150-275  275-425  425-750  750-1500  > 1500  Hz
  *   #180 curve  -12     -14      -15      -11       -3        0    dB
- *   this table   -6      -7      -7.5     -5.5      -1.5      0    dB
+ *   previous     -6      -7      -7.5     -5.5      -1.5      0    dB
+ *   this table  -18     -15     -10       -4        0        +4    dB
  */
 static const int32_t static_gain_q15[SPK_PROTECT_BANDS] = {
-	16423, 14637, 13818, 17397, 27571, 32768,
+	4125, 5827, 10362, 20675, 32768, 51934,
 };
 
 /* Per-band current weights (Q12, 4096 = 1.0) for the limiter sidechain.
  *
- * Approximates SYSTEM supply-current draw per unit signal amplitude vs
- * frequency. The low bands are derived by inverting the issue #180
- * protection depths (the empirically measured "how much this band had to be
- * cut" is a direct proxy for "how much current this band draws"). The #180
- * data only characterised low-frequency content; on-device testing showed
- * full-scale BROADBAND noise tripping the battery IC even when the weighted
- * envelope was within budget (Class-D amplifier losses and transducer
- * behaviour above 750 Hz draw more than the inverted-EQ model predicted),
- * so the two top bands carry defensive uplifts (1.4 -> 2.5, 1.0 -> 2.0)
- * pending bench calibration that must include noise, not just sine sweeps.
+ * Bench-calibrated (PSU + ammeter, tones through the full chain, 3.7 V):
+ * once the voicing curve's per-band amplitude differences are divided out,
+ * supply current is a function of drive AMPLITUDE alone - flat within a
+ * few percent from 150 Hz to 2 kHz, following roughly
  *
- * Budget reference: a >= 1.5 kHz sine at weight 2.0 - i.e. budget_percent
- * is measured against the top band's weighted amplitude.
+ *   I_audio ~= 1550 mA * (output RMS / full scale)^1.8
  *
- *   band    < 150  150-275  275-425  425-750  750-1500  > 1500  Hz
- *   weight   4.0     5.0      5.6      3.5      2.5       2.0
+ * (fit reproduces the bench budget ladder 21/42/72/110 mA audio at budgets
+ * 40/60/80/100 and the level ladder). The previous table's "low bands cost
+ * 2-3x more" shape was an artifact of the inverted-EQ heuristic: the old
+ * voicing attenuated the lows, and per-unit-INPUT current comparisons
+ * conflated that with transducer physics.
+ *
+ * Uniform weights make the sidechain proxy track output amplitude exactly,
+ * so the budget caps current honestly for any spectrum - sines, speech and
+ * broadband noise alike - at either sample rate. The value 3.0 anchors
+ * budget 80 to the bench-measured safe ceiling (~72 mA audio: a sustained
+ * sine is clamped to 0.8/3.0 of full scale peak in any band).
  */
 static const int32_t current_weight_q12[SPK_PROTECT_BANDS] = {
-	16384, 20480, 22938, 14336, 10240, 8192,
+	12288, 12288, 12288, 12288, 12288, 12288,
 };
 
 /* Bands below this index get the limiter gain cubed (3x the dB reduction)

--- a/drivers/audio/max98357a/speaker_protect.h
+++ b/drivers/audio/max98357a/speaker_protect.h
@@ -17,9 +17,10 @@
  *                                     resonance where current is pure waste)
  *     -> 6-band split                (cascaded one-pole low-passes; magnitude
  *                                     complementary, cheap, phase coherent)
- *     -> static voicing gains        (mild; roughly half the issue #180
- *                                     protection depths in dB - the energy
- *                                     limiter below now carries protection)
+ *     -> static voicing gains        (loudness rebalance: cut the
+ *                                     vibrotactile lows, boost the audible
+ *                                     top band - the energy limiter below
+ *                                     carries the protection duty)
  *     -> current-proxy energy limiter:
  *          sidechain = sum over channels of |sum(band * current_weight)|,
  *          squared and leaky-integrated over ~ENV ms to approximate the
@@ -36,15 +37,15 @@
  *
  * Budget calibration: budget_percent is the amplitude, as a percentage of
  * int16 full scale, of a hypothetical weight-1.0 sine whose steady-state
- * weighted energy the limiter will allow. Every band carries a current
- * weight >= 2.0 (see current_weight_q12), so e.g. a >= 1.5 kHz sine
- * (weight 2.0) is allowed budget/2 of full scale sustained, and a 300 Hz
- * sine (weight 5.6) budget/5.6. Calibrate on the bench with full-scale
- * sine sweeps, BROADBAND NOISE, and real TTS at max volume in stereo:
- * find the largest budget that keeps battery current below the protection
- * IC's trip point with margin, and set the Kconfig default accordingly.
- * (Noise matters: the field failure that motivated the HF weight uplifts
- * was full-scale broadband garbage from a misconfigured LC3 decoder.)
+ * weighted energy the limiter will allow. The current weights are uniform
+ * 3.0 (bench calibration showed supply current tracks drive amplitude,
+ * not frequency - see current_weight_q12 in the .c), so a sustained sine
+ * in any band is allowed budget/3 of full scale. Calibrate on the bench
+ * with full-scale sine sweeps, BROADBAND NOISE, and real TTS at max
+ * volume: find the largest budget that keeps battery current below the
+ * protection IC's trip point with margin, and set the Kconfig default
+ * accordingly. (Noise matters: an early field failure was full-scale
+ * broadband garbage from a misconfigured LC3 decoder.)
  */
 
 #ifndef SPEAKER_PROTECT_H_

--- a/drivers/audio/max98357a/speaker_protect.h
+++ b/drivers/audio/max98357a/speaker_protect.h
@@ -78,6 +78,17 @@ struct spk_protect_params {
 	int hold_ms;         /**< limiter hold before release starts */
 	int release_ms;      /**< limiter release time constant */
 	int ramp_ms;         /**< onset ramp after reset; 0 disables */
+	int bass_drive_percent; /**< psychoacoustic bass harmonic mix, percent
+				 *   of the source-band level; 0 disables,
+				 *   up to 200 */
+};
+
+/** Limiter activity counters; see spk_protect_stats_read(). */
+struct spk_protect_stats {
+	int32_t min_gain_q15;   /**< lowest limiter gain seen (Q15) */
+	uint32_t frames;        /**< frames processed */
+	uint32_t limited_frames;/**< frames with gain below unity */
+	int32_t peak_out;       /**< largest |output sample| */
 };
 
 /** Per-channel filter state. */
@@ -87,6 +98,14 @@ struct spk_protect_channel {
 	int64_t hpf_z2;
 	/* One-pole low-pass states, Q15-extended sample domain */
 	int32_t lp[SPK_PROTECT_SPLITS];
+	/* Psychoacoustic bass enhancer states (Q15-extended) */
+	int32_t bass_lp_lo;   /**< source band low edge (60 Hz LP) */
+	int32_t bass_lp_hi;   /**< source band high edge (240 Hz LP, pole 1) */
+	int32_t bass_lp_hi2;  /**< source band high edge (240 Hz LP, pole 2:
+			       *   12 dB/oct keeps voice mids out of the
+			       *   rectifier) */
+	int32_t bass_lp_dc;   /**< DC/fundamental tracker on rectified band */
+	int32_t bass_lp_out;  /**< harmonic top shaping (900 Hz LP) */
 };
 
 struct spk_protect {
@@ -98,6 +117,28 @@ struct spk_protect {
 
 	/* One-pole split coefficients (Q15) */
 	int32_t alpha_q15[SPK_PROTECT_SPLITS];
+
+	/* Per-instance voicing gains / current weights (defaults copied at
+	 * init; overridable for bench tuning via the setters below).
+	 */
+	int32_t voicing_q15[SPK_PROTECT_BANDS];
+	int32_t weight_q12[SPK_PROTECT_BANDS];
+
+	/* Digital pre-gain applied before the HPF (Q15; may exceed unity up
+	 * to 4x). The limiter sidechain sees the boosted signal, so the
+	 * energy budget still caps real transducer drive.
+	 */
+	int32_t pregain_q15;
+
+	struct spk_protect_stats stats;
+
+	/* Psychoacoustic bass enhancer */
+	bool bass_enabled;
+	int32_t bass_drive_q15;   /**< harmonic mix gain */
+	int32_t bass_alpha_lo;    /**< one-pole alphas (Q15) */
+	int32_t bass_alpha_hi;
+	int32_t bass_alpha_dc;
+	int32_t bass_alpha_out;
 
 	struct spk_protect_channel ch[SPK_PROTECT_MAX_CHANNELS];
 
@@ -146,6 +187,42 @@ static inline int32_t spk_protect_gain_q15(const struct spk_protect *sp)
 {
 	return sp->gain_q15;
 }
+
+/**
+ * @brief Override the static voicing gains (Q15 per band).
+ *
+ * NULL restores the built-in defaults. Takes effect from the next sample.
+ */
+void spk_protect_set_voicing(struct spk_protect *sp,
+			     const int32_t gains_q15[SPK_PROTECT_BANDS]);
+
+/**
+ * @brief Override the limiter sidechain current weights (Q12 per band).
+ *
+ * NULL restores the built-in defaults.
+ */
+void spk_protect_set_weights(struct spk_protect *sp,
+			     const int32_t weights_q12[SPK_PROTECT_BANDS]);
+
+/**
+ * @brief Set the digital pre-gain (Q15; clamped to [0, 4 * Q15_ONE]).
+ */
+void spk_protect_set_pregain(struct spk_protect *sp, int32_t pregain_q15);
+
+/** @brief dB*10 (e.g. -75 = -7.5 dB) to Q15 linear gain; saturates at 4x. */
+int32_t spk_protect_db10_to_q15(int db10);
+
+/**
+ * @brief Read limiter activity counters accumulated since the last reset.
+ *
+ * @param reset clear the counters after reading
+ */
+void spk_protect_stats_read(struct spk_protect *sp,
+			    struct spk_protect_stats *out, bool reset);
+
+/** @brief Built-in default tables (Q15 gains / Q12 weights). */
+const int32_t *spk_protect_default_voicing(void);
+const int32_t *spk_protect_default_weights(void);
 
 #ifdef __cplusplus
 }

--- a/drivers/audio/max98357a/speaker_protect.h
+++ b/drivers/audio/max98357a/speaker_protect.h
@@ -146,7 +146,18 @@ struct spk_protect {
 	/* Limiter */
 	int64_t env;            /**< leaky-integrated proxy energy */
 	int32_t env_shift;      /**< integrator: env += (p2 - env) >> shift */
-	int64_t threshold_env;  /**< energy budget in envelope units */
+	int64_t threshold_env;  /**< energy budget in envelope units (current,
+				 *   may be mid-slew toward threshold_target) */
+
+	/* Runtime budget reduction (display-aware ducking). The request is a
+	 * single aligned int32 store, safe from another thread; the process
+	 * loop applies it by slewing threshold_env to the recomputed target
+	 * over ~ramp_ms (snapped while the onset ramp is still active).
+	 */
+	int32_t budget_drop_req;     /**< requested drop, percent points */
+	int32_t budget_drop_applied; /**< drop threshold_target reflects */
+	int64_t threshold_target;    /**< slew target */
+	int64_t threshold_step;      /**< per-frame slew increment */
 	int32_t gain_q15;       /**< current limiter gain (Q15) */
 	int32_t hold_samples;   /**< configured hold length */
 	int32_t hold_left;      /**< frames of hold remaining */
@@ -209,6 +220,18 @@ void spk_protect_set_weights(struct spk_protect *sp,
  * @brief Set the digital pre-gain (Q15; clamped to [0, 4 * Q15_ONE]).
  */
 void spk_protect_set_pregain(struct spk_protect *sp, int32_t pregain_q15);
+
+/**
+ * @brief Reduce the energy budget by drop_percent points at runtime.
+ *
+ * Effective budget = max(budget_percent - drop_percent, 5). Intended for
+ * ducking audio while another large load (the display) shares the battery
+ * protection IC's current allowance. Thread-safe against a running
+ * process(): the change is picked up per frame and the threshold slews
+ * over ~ramp_ms, so a mid-stream toggle becomes a smooth ramped step
+ * instead of a click. 0 restores the configured budget.
+ */
+void spk_protect_set_budget_drop(struct spk_protect *sp, int drop_percent);
 
 /** @brief dB*10 (e.g. -75 = -7.5 dB) to Q15 linear gain; saturates at 4x. */
 int32_t spk_protect_db10_to_q15(int db10);

--- a/drivers/audio/max98357a/speaker_protect.h
+++ b/drivers/audio/max98357a/speaker_protect.h
@@ -82,6 +82,14 @@ struct spk_protect_params {
 	int bass_drive_percent; /**< psychoacoustic bass harmonic mix, percent
 				 *   of the source-band level; 0 disables,
 				 *   up to 200 */
+	int peak_cap_percent;   /**< true-peak clamp on the instantaneous
+				 *   weighted drive, % of full scale (same
+				 *   units as budget_percent); guards the
+				 *   battery IC's fast short-circuit
+				 *   comparator against transients inside the
+				 *   energy sidechain's ~env_ms blind window.
+				 *   Must sit above the budget (crest room);
+				 *   0 disables */
 };
 
 /** Limiter activity counters; see spk_protect_stats_read(). */
@@ -90,6 +98,7 @@ struct spk_protect_stats {
 	uint32_t frames;        /**< frames processed */
 	uint32_t limited_frames;/**< frames with gain below unity */
 	int32_t peak_out;       /**< largest |output sample| */
+	uint32_t peak_capped_frames; /**< frames the true-peak clamp engaged */
 };
 
 /** Per-channel filter state. */
@@ -162,6 +171,11 @@ struct spk_protect {
 	int32_t hold_samples;   /**< configured hold length */
 	int32_t hold_left;      /**< frames of hold remaining */
 	int32_t release_shift;  /**< gain += (ONE - gain) >> shift per frame */
+
+	/* True-peak current clamp (instant attack, ~4 ms release) */
+	int64_t peak_cap;          /**< cap in weighted proxy units; 0 = off */
+	int32_t peak_gain_q15;     /**< current clamp gain */
+	int32_t peak_release_shift;/**< release: gain += (target-gain) >> shift */
 
 	/* Onset ramp */
 	int32_t ramp_q15;       /**< 0..Q15_ONE */

--- a/modules/halo/include/halo/audio_stream.h
+++ b/modules/halo/include/halo/audio_stream.h
@@ -205,6 +205,24 @@ int audio_speaker_set_volume_transient(audio_speaker_t *spk, int volume);
 int audio_speaker_set_stream_gain(audio_speaker_t *spk, int gain_db10);
 
 /**
+ * @brief Set the per-stream energy-budget override (percent, 0 = none)
+ *
+ * Lets a stream choose its loudness/current envelope up to the
+ * Kconfig-clamped maximum (default 100, the loudest bench-validated
+ * point). Any override engages the fast limiter integration window,
+ * which is what makes raised budgets safe against transient exposure.
+ * All protection stays active (weights, limiter, true-peak clamp,
+ * display budget drop). Transient: cleared on every
+ * audio_speaker_init(). Must be set before the stream starts (it takes
+ * effect when the protection chain is built).
+ *
+ * @param spk Speaker handle
+ * @param budget_percent 10..100, or 0 to restore the configured default
+ * @return 0 on success, negative errno on failure
+ */
+int audio_speaker_set_stream_budget(audio_speaker_t *spk, int budget_percent);
+
+/**
  * @brief Tell the audio path whether the display is out of power save
  *
  * The display's supply current shares the battery protection IC with the

--- a/modules/halo/include/halo/audio_stream.h
+++ b/modules/halo/include/halo/audio_stream.h
@@ -205,6 +205,19 @@ int audio_speaker_set_volume_transient(audio_speaker_t *spk, int volume);
 int audio_speaker_set_stream_gain(audio_speaker_t *spk, int gain_db10);
 
 /**
+ * @brief Tell the audio path whether the display is out of power save
+ *
+ * The display's supply current shares the battery protection IC with the
+ * speakers, so the protection chain ducks its energy budget while the
+ * display is active (a smooth ramped step, even mid-stream) and restores
+ * it when the display sleeps. Called from the display power path; the
+ * coupling is one-directional (display -> audio).
+ *
+ * @param active true when the display leaves power save, false on entry
+ */
+void audio_speaker_notify_display_active(bool active);
+
+/**
  * @brief Get speaker volume
  *
  * @param spk Speaker handle

--- a/modules/halo/include/halo/audio_stream.h
+++ b/modules/halo/include/halo/audio_stream.h
@@ -190,6 +190,21 @@ int audio_speaker_set_volume(audio_speaker_t *spk, int volume);
 int audio_speaker_set_volume_transient(audio_speaker_t *spk, int volume);
 
 /**
+ * @brief Set the per-stream digital pre-gain (dB*10, 0..+120)
+ *
+ * Boosts the signal into the protection chain's limiter: quiet sources
+ * (e.g. un-normalized TTS) get louder, hot sources are compressed - the
+ * current budget still caps real transducer drive. Transient: cleared to
+ * unity on every audio_speaker_init(), so it applies to the current
+ * playback session only.
+ *
+ * @param spk Speaker handle
+ * @param gain_db10 Gain in dB*10 (e.g. 60 = +6 dB); 0 restores unity
+ * @return 0 on success, negative errno on failure
+ */
+int audio_speaker_set_stream_gain(audio_speaker_t *spk, int gain_db10);
+
+/**
  * @brief Get speaker volume
  *
  * @param spk Speaker handle

--- a/modules/halo/src/audio_stream.c
+++ b/modules/halo/src/audio_stream.c
@@ -17,6 +17,10 @@
 #include <halo/audio_eq.h>
 #endif
 
+#if defined(CONFIG_MAX98357A_AUDIO)
+#include <max98357a_audio.h>
+#endif
+
 LOG_MODULE_REGISTER(audio_stream, CONFIG_HALO_LOG_LEVEL);
 
 static const char *audio_owner_name(audio_owner_t owner)
@@ -345,6 +349,13 @@ audio_speaker_t *audio_speaker_init(int sample_rate, int bit_depth, int channels
 		return NULL;
 	}
 
+#if defined(CONFIG_MAX98357A_AUDIO)
+	/* Per-stream pre-gain is transient: every acquisition starts at
+	 * unity so one owner's gain cannot leak into the next stream.
+	 */
+	max98357a_audio_set_stream_pregain(0);
+#endif
+
 	/* Configure audio parameters */
 	speaker_singleton.speaker.config.sample_rate = sample_rate;
 	speaker_singleton.speaker.config.bits_per_sample = bit_depth;
@@ -487,6 +498,23 @@ int audio_speaker_set_volume(audio_speaker_t *spk, int volume)
 int audio_speaker_set_volume_transient(audio_speaker_t *spk, int volume)
 {
 	return audio_speaker_set_volume_internal(spk, volume, false);
+}
+
+int audio_speaker_set_stream_gain(audio_speaker_t *spk, int gain_db10)
+{
+	if (!spk) {
+		return -EINVAL;
+	}
+	if (gain_db10 < 0 || gain_db10 > 120) {
+		return -EINVAL;
+	}
+
+#if defined(CONFIG_MAX98357A_AUDIO)
+	max98357a_audio_set_stream_pregain(gain_db10);
+	return 0;
+#else
+	return (gain_db10 == 0) ? 0 : -ENOTSUP;
+#endif
 }
 
 int audio_speaker_get_volume(audio_speaker_t *spk)

--- a/modules/halo/src/audio_stream.c
+++ b/modules/halo/src/audio_stream.c
@@ -500,6 +500,15 @@ int audio_speaker_set_volume_transient(audio_speaker_t *spk, int volume)
 	return audio_speaker_set_volume_internal(spk, volume, false);
 }
 
+void audio_speaker_notify_display_active(bool active)
+{
+#if defined(CONFIG_MAX98357A_AUDIO)
+	max98357a_audio_set_display_active(active);
+#else
+	ARG_UNUSED(active);
+#endif
+}
+
 int audio_speaker_set_stream_gain(audio_speaker_t *spk, int gain_db10)
 {
 	if (!spk) {

--- a/modules/halo/src/audio_stream.c
+++ b/modules/halo/src/audio_stream.c
@@ -350,10 +350,12 @@ audio_speaker_t *audio_speaker_init(int sample_rate, int bit_depth, int channels
 	}
 
 #if defined(CONFIG_MAX98357A_AUDIO)
-	/* Per-stream pre-gain is transient: every acquisition starts at
-	 * unity so one owner's gain cannot leak into the next stream.
+	/* Per-stream pre-gain and boost profile are transient: every
+	 * acquisition starts at the defaults so one owner's settings
+	 * cannot leak into the next stream.
 	 */
 	max98357a_audio_set_stream_pregain(0);
+	max98357a_audio_set_stream_budget(0);
 #endif
 
 	/* Configure audio parameters */
@@ -506,6 +508,23 @@ void audio_speaker_notify_display_active(bool active)
 	max98357a_audio_set_display_active(active);
 #else
 	ARG_UNUSED(active);
+#endif
+}
+
+int audio_speaker_set_stream_budget(audio_speaker_t *spk, int budget_percent)
+{
+	if (!spk) {
+		return -EINVAL;
+	}
+	if (budget_percent < 0 || budget_percent > 100) {
+		return -EINVAL;
+	}
+
+#if defined(CONFIG_MAX98357A_AUDIO)
+	max98357a_audio_set_stream_budget(budget_percent);
+	return 0;
+#else
+	return (budget_percent == 0) ? 0 : -ENOTSUP;
 #endif
 }
 

--- a/modules/halo/src/lua_display.c
+++ b/modules/halo/src/lua_display.c
@@ -247,6 +247,18 @@ static int display_resume_handler(void)
 
 	/* Note: Framework only calls this if needs_resume=true */
 
+#if defined(CONFIG_HALO_AUDIO_STREAM)
+	/* Duck the audio budget BEFORE the panel starts drawing: the resume
+	 * sequence pulls its load immediately, and full-budget audio plus
+	 * display inrush stacked on the battery-protection IC is the exact
+	 * trip scenario the budget drop exists to prevent (bench: the
+	 * post-resume ordering spiked ~+24 mA for the whole resume). The
+	 * ducking ramp (~15 ms) runs while the resume proceeds. Suspend
+	 * keeps the reverse order - restore only after the load is gone.
+	 */
+	audio_speaker_notify_display_active(true);
+#endif
+
 #ifdef CONFIG_PM_DEVICE
 	if (display_state.panel) {
 		enum pm_device_state pm_state;
@@ -255,6 +267,10 @@ static int display_resume_handler(void)
 			ret = pm_device_action_run(display_state.panel, PM_DEVICE_ACTION_RESUME);
 			if (ret != 0) {
 				LOG_ERR("Failed to resume panel: %d", ret);
+#if defined(CONFIG_HALO_AUDIO_STREAM)
+				/* display did not come up: restore the budget */
+				audio_speaker_notify_display_active(false);
+#endif
 				return ret;
 			}
 		}
@@ -266,6 +282,9 @@ static int display_resume_handler(void)
 		ret = dsi_dw_set_mode(display_state.dsi, DSI_DW_VIDEO_MODE);
 		if (ret != 0) {
 			LOG_ERR("Failed to set DSI to video mode: %d", ret);
+#if defined(CONFIG_HALO_AUDIO_STREAM)
+			audio_speaker_notify_display_active(false);
+#endif
 			return ret;
 		}
 	}
@@ -305,11 +324,6 @@ static int display_resume_handler(void)
 
 	/* Note: is_active state managed by service framework */
 	display_state.hw_active = true;
-
-#if defined(CONFIG_HALO_AUDIO_STREAM)
-	/* Display load now rides the battery IC: duck the audio budget */
-	audio_speaker_notify_display_active(true);
-#endif
 
 	return 0; /* Always return success - errors are logged */
 }

--- a/modules/halo/src/lua_display.c
+++ b/modules/halo/src/lua_display.c
@@ -22,6 +22,9 @@
 #include <halo/lua_runtime.h>
 #include <halo/pm_manager.h>
 #include <halo/file_manager.h>
+#if defined(CONFIG_HALO_AUDIO_STREAM)
+#include <halo/audio_stream.h>
+#endif
 
 LOG_MODULE_REGISTER(lua_display, CONFIG_HALO_LOG_LEVEL);
 
@@ -227,6 +230,11 @@ static int display_suspend_handler(void)
 	/* Note: is_active state managed by service framework */
 	display_state.hw_active = false;
 
+#if defined(CONFIG_HALO_AUDIO_STREAM)
+	/* Display load off the battery IC: restore the audio budget */
+	audio_speaker_notify_display_active(false);
+#endif
+
 	return 0; /* Return 0 to indicate successful suspend (needs resume) */
 }
 
@@ -297,6 +305,11 @@ static int display_resume_handler(void)
 
 	/* Note: is_active state managed by service framework */
 	display_state.hw_active = true;
+
+#if defined(CONFIG_HALO_AUDIO_STREAM)
+	/* Display load now rides the battery IC: duck the audio budget */
+	audio_speaker_notify_display_active(true);
+#endif
 
 	return 0; /* Always return success - errors are logged */
 }

--- a/modules/halo/src/lua_speaker.c
+++ b/modules/halo/src/lua_speaker.c
@@ -304,6 +304,12 @@ static void speaker_stop_thread(void)
  *     (default: 0). Lifts quiet sources (e.g. un-normalized TTS) toward
  *     the loudness ceiling; hot sources are compressed instead of
  *     getting louder. Transient: applies to this stream only.
+ *   - budget: 10-100, per-stream energy-budget override (default:
+ *     the configured budget). Higher = louder ceiling, more battery
+ *     current; any override engages the fast limiter attack that
+ *     makes raised budgets safe. Clamped to the Kconfig maximum. All
+ *     protection stays active. budget=100 with gain=12 is the loudest
+ *     supported voice. Transient per stream.
  *
  * For LC3 stereo: Input format is [Left LC3][Right LC3]...
  * Output PCM will be interleaved LRLRLR...
@@ -423,6 +429,19 @@ static int lua_speaker_start(lua_State *L)
 		return luaL_error(L, "Gain must be 0-12 dB");
 	}
 
+	/* budget (per-stream energy-budget override) */
+	int budget = 0;
+
+	lua_getfield(L, 1, "budget");
+	if (lua_isnumber(L, -1)) {
+		budget = lua_tointeger(L, -1);
+	}
+	lua_pop(L, 1);
+
+	if (budget != 0 && (budget < 10 || budget > 100)) {
+		return luaL_error(L, "Budget must be 10-100");
+	}
+
 	/* Save configuration */
 	speaker_state.sample_rate = sample_rate;
 	speaker_state.channel_count = channels;
@@ -434,6 +453,13 @@ static int lua_speaker_start(lua_State *L)
 						   AUDIO_OWNER_LUA);
 	if (!speaker_state.speaker) {
 		return luaL_error(L, "Failed to initialize speaker (may be occupied by LE Audio)");
+	}
+
+	/* The budget override must land before the stream starts (the
+	 * protection chain rebuilds while the stream is stopped).
+	 */
+	if (budget > 0) {
+		audio_speaker_set_stream_budget(speaker_state.speaker, budget);
 	}
 
 	/* Initialize LC3 decoder if needed */

--- a/modules/halo/src/lua_speaker.c
+++ b/modules/halo/src/lua_speaker.c
@@ -300,6 +300,10 @@ static void speaker_stop_thread(void)
  *   - duration: 750 or 1000 (default: 1000, LC3 only)
  *   - bitrate: 8000-96000 (default: 16000, LC3 only)
  *   - volume: 0-100 (default: 50)
+ *   - gain: 0-12 dB digital pre-gain into the protection limiter
+ *     (default: 0). Lifts quiet sources (e.g. un-normalized TTS) toward
+ *     the loudness ceiling; hot sources are compressed instead of
+ *     getting louder. Transient: applies to this stream only.
  *
  * For LC3 stereo: Input format is [Left LC3][Right LC3]...
  * Output PCM will be interleaved LRLRLR...
@@ -406,6 +410,19 @@ static int lua_speaker_start(lua_State *L)
 		return luaL_error(L, "Volume must be 0-100");
 	}
 
+	/* gain (per-stream pre-gain into the protection limiter, dB) */
+	int gain_db = 0;
+
+	lua_getfield(L, 1, "gain");
+	if (lua_isnumber(L, -1)) {
+		gain_db = lua_tointeger(L, -1);
+	}
+	lua_pop(L, 1);
+
+	if (gain_db < 0 || gain_db > 12) {
+		return luaL_error(L, "Gain must be 0-12 dB");
+	}
+
 	/* Save configuration */
 	speaker_state.sample_rate = sample_rate;
 	speaker_state.channel_count = channels;
@@ -472,6 +489,11 @@ static int lua_speaker_start(lua_State *L)
 
 	/* Set volume */
 	audio_speaker_set_volume(speaker_state.speaker, volume);
+
+	/* Per-stream pre-gain (audio_speaker_init reset it to unity) */
+	if (gain_db > 0) {
+		audio_speaker_set_stream_gain(speaker_state.speaker, gain_db * 10);
+	}
 
 	/* Start background thread if not already running */
 	if (!speaker_state.thread_tid) {

--- a/tests/audio/speaker_protect/.gitignore
+++ b/tests/audio/speaker_protect/.gitignore
@@ -1,2 +1,4 @@
 test_speaker_protect
 test_speaker_protect.dSYM/
+wav_lab
+wav_lab.dSYM/

--- a/tests/audio/speaker_protect/main.c
+++ b/tests/audio/speaker_protect/main.c
@@ -49,8 +49,23 @@ static struct spk_protect_params params_default(int channels)
 		.hold_ms = 20,
 		.release_ms = 150,
 		.ramp_ms = 15,
+		.bass_drive_percent = 0,
 	};
 	return p;
+}
+
+/** Goertzel magnitude of one bin (double precision). */
+static double goertzel(const int16_t *buf, size_t n, double freq, double fs)
+{
+	double k = 2.0 * cos(2.0 * PI * freq / fs);
+	double s0, s1 = 0, s2 = 0;
+
+	for (size_t i = 0; i < n; i++) {
+		s0 = buf[i] + k * s1 - s2;
+		s2 = s1;
+		s1 = s0;
+	}
+	return sqrt(s1 * s1 + s2 * s2 - k * s1 * s2) / (n / 2.0);
 }
 
 static void gen_sine(int16_t *buf, size_t n, double freq, double amp_fs)
@@ -482,6 +497,129 @@ static void test_noise_energy_cap(void)
 	      spk_protect_gain_q15(&sp) / 32768.0);
 }
 
+static void test_bass_enhancer(void)
+{
+	printf("psychoacoustic bass enhancer:\n");
+
+	enum { N = 2 * FS };
+	static int16_t off_buf[N], on_buf[N];
+	struct spk_protect sp;
+	struct spk_protect_params p = params_default(1);
+
+	p.ramp_ms = 0;
+
+	/* -20 dBFS 100 Hz: below the HPF, inside the source band, limiter idle */
+	gen_sine(off_buf, N, 100, 0.1);
+	memcpy(on_buf, off_buf, sizeof(off_buf));
+
+	spk_protect_init(&sp, &p);          /* drive 0: enhancer off */
+	spk_protect_process(&sp, off_buf, N);
+
+	p.bass_drive_percent = 100;
+	spk_protect_init(&sp, &p);
+	spk_protect_process(&sp, on_buf, N);
+
+	/* Analyse the settled tail */
+	const int16_t *off_t = off_buf + N / 2, *on_t = on_buf + N / 2;
+	double h2_off = goertzel(off_t, N / 2, 200, FS);
+	double h2_on = goertzel(on_t, N / 2, 200, FS);
+	double h4_on = goertzel(on_t, N / 2, 400, FS);
+	double f0_on = goertzel(on_t, N / 2, 100, FS);
+
+	printf("    100 Hz in -> 100 Hz: %.0f | 200 Hz: %.0f (off: %.0f) | 400 Hz: %.0f\n",
+	       f0_on, h2_on, h2_off, h4_on);
+
+	CHECK(h2_on > 4.0 * (h2_off + 1.0),
+	      "2nd harmonic (200 Hz) generated: %.0f vs %.0f without", h2_on, h2_off);
+	/* The 130 Hz HPF only takes ~6 dB at 100 Hz, so the residual
+	 * fundamental legitimately stays larger than the harmonics. Assert a
+	 * floor on the harmonic-to-residual ratio at drive 100; the actual
+	 * voicing level is tuned by ear via the drive knob (linear scaling).
+	 */
+	CHECK(h2_on > 0.15 * f0_on,
+	      "2nd harmonic vs residual fundamental: %.2fx at drive 100 (floor 0.15)",
+	      h2_on / f0_on);
+
+	/* Content above the source band must pass clean: 1 kHz in, no 2 kHz */
+	static int16_t hf_buf[N];
+
+	gen_sine(hf_buf, N, 1000, 0.1);
+	spk_protect_init(&sp, &p);
+	spk_protect_process(&sp, hf_buf, N);
+
+	double hf_h2 = goertzel(hf_buf + N / 2, N / 2, 2000, FS);
+	double hf_f0 = goertzel(hf_buf + N / 2, N / 2, 1000, FS);
+
+	CHECK(hf_h2 < 0.02 * hf_f0,
+	      "1 kHz content stays clean (2 kHz at %.1f%% of fundamental)",
+	      100.0 * hf_h2 / hf_f0);
+}
+
+static void test_bass_enhancer_safety(void)
+{
+	printf("bass enhancer cannot break the current budget (max drive):\n");
+
+	enum { N = 2 * FS };
+	static int16_t buf[N];
+	struct spk_protect sp;
+	struct spk_protect_params p = params_default(1);
+
+	p.ramp_ms = 0;
+	p.bass_drive_percent = 200;
+	spk_protect_init(&sp, &p);
+
+	gen_sine(buf, N, 100, 1.0); /* full-scale, worst source-band case */
+	spk_protect_process(&sp, buf, N);
+
+	struct ref_sidechain ref;
+
+	ref_sidechain_init(&ref, FS, p.env_ms);
+
+	double max_env = 0;
+
+	for (size_t i = 0; i < N; i++) {
+		double env = ref_sidechain_step(&ref, &buf[i], 1);
+
+		if (i > (size_t)N / 2 && env > max_env) {
+			max_env = env;
+		}
+	}
+
+	CHECK(max_env <= budget_threshold() * 1.25,
+	      "full-scale 100 Hz at drive 200%%: energy x%.2f of budget",
+	      max_env / budget_threshold());
+}
+
+static void test_bass_enhancer_chunk_equivalence(void)
+{
+	printf("enhancer state continuity across buffer boundaries:\n");
+
+	enum { N = FS / 2 };
+	static int16_t whole[N], chunked[N];
+	struct spk_protect sp_a, sp_b;
+	struct spk_protect_params p = params_default(1);
+
+	p.bass_drive_percent = 100;
+	spk_protect_init(&sp_a, &p);
+	spk_protect_init(&sp_b, &p);
+
+	for (size_t i = 0; i < N; i++) {
+		double v = 0.6 * sin(2 * PI * 120 * i / (double)FS) +
+			   0.3 * sin(2 * PI * 800 * i / (double)FS);
+
+		whole[i] = (int16_t)lrint(30000.0 * v);
+	}
+	memcpy(chunked, whole, sizeof(whole));
+
+	spk_protect_process(&sp_a, whole, N);
+	for (size_t off = 0; off < N; off += 160) {
+		spk_protect_process(&sp_b, chunked + off, 160);
+	}
+
+	CHECK(memcmp(whole, chunked, sizeof(whole)) == 0,
+	      "chunked output bit-exact with enhancer active");
+}
+
 static void test_param_validation(void)
 {
 	printf("parameter validation:\n");
@@ -501,8 +639,11 @@ static void test_param_validation(void)
 	p = params_default(1);
 	p.sample_rate = 4000;
 	ok &= (spk_protect_init(&sp, &p) != 0);
+	p = params_default(1);
+	p.bass_drive_percent = 201;
+	ok &= (spk_protect_init(&sp, &p) != 0);
 
-	CHECK(ok, "invalid channels/budget/cutoff/rate all rejected");
+	CHECK(ok, "invalid channels/budget/cutoff/rate/drive all rejected");
 }
 
 int main(void)
@@ -521,6 +662,9 @@ int main(void)
 	test_worst_case_safety();
 	test_8k_smoke();
 	test_noise_energy_cap();
+	test_bass_enhancer();
+	test_bass_enhancer_safety();
+	test_bass_enhancer_chunk_equivalence();
 	test_param_validation();
 
 	printf("\n%s (%d failure%s)\n", g_failures ? "FAILED" : "ALL TESTS PASSED",

--- a/tests/audio/speaker_protect/main.c
+++ b/tests/audio/speaker_protect/main.c
@@ -43,7 +43,7 @@ static struct spk_protect_params params_default(int channels)
 	struct spk_protect_params p = {
 		.sample_rate = FS,
 		.channels = channels,
-		.hpf_cutoff_hz = 130,
+		.hpf_cutoff_hz = 200,
 		.budget_percent = BUDGET,
 		.env_ms = 3,
 		.hold_ms = 20,
@@ -96,7 +96,7 @@ static double db(double ratio)
  * no code with the fixed-point implementation.
  */
 static const double ref_split_hz[5] = { 150, 275, 425, 750, 1500 };
-static const double ref_weight[6] = { 4.0, 5.0, 5.6, 3.5, 2.5, 2.0 };
+static const double ref_weight[6] = { 3.0, 3.0, 3.0, 3.0, 3.0, 3.0 };
 
 struct ref_sidechain {
 	double lp[5];
@@ -196,7 +196,11 @@ static void test_small_signal_response(void)
 	      "300 Hz voice band: %+.1f dB (was ~-18 dB in old stacked chain)", gains[2]);
 	CHECK(gains[0] < -15.0, "60 Hz (below resonance) strongly cut: %+.1f dB", gains[0]);
 	CHECK(gains[4] > -4.0, "1 kHz nearly intact: %+.1f dB", gains[4]);
-	CHECK(gains[5] > -2.0 && gains[5] < 1.0, "3 kHz ~flat: %+.1f dB", gains[5]);
+	/* Rebal voicing boosts the top band +4 dB (audible loudness per unit
+	 * current); split leakage from the flat neighbours pulls the measured
+	 * boost at 3 kHz down to ~+2.5 dB.
+	 */
+	CHECK(gains[5] > 1.0 && gains[5] < 4.5, "3 kHz boosted: %+.1f dB", gains[5]);
 	CHECK(gains[0] < gains[1] && gains[1] < gains[2] && gains[2] < gains[4],
 	      "response monotonically rising through voice band");
 }
@@ -224,6 +228,13 @@ static void test_energy_cap(double freq, int nch, const char *label)
 
 	spk_protect_process(&sp, buf, (size_t)N * nch);
 
+	/* Sub-resonance content (the 80 Hz case) is held inside the budget by
+	 * the HPF + voicing alone - by design - so the limiter legitimately
+	 * never engages there; only assert engagement where the static
+	 * filters cannot do the job.
+	 */
+	bool expect_limiting = freq > 150;
+
 	/* Verify with the independent sidechain over the settled tail. */
 	struct ref_sidechain ref;
 
@@ -244,9 +255,14 @@ static void test_energy_cap(double freq, int nch, const char *label)
 	CHECK(max_env <= thr * 1.25,
 	      "%s: settled weighted energy %.3g <= budget %.3g (x%.2f)",
 	      label, max_env, thr, max_env / thr);
-	CHECK(spk_protect_gain_q15(&sp) < SPK_PROTECT_Q15_ONE,
-	      "%s: limiter engaged (gain %.3f)", label,
-	      spk_protect_gain_q15(&sp) / 32768.0);
+	if (expect_limiting) {
+		CHECK(spk_protect_gain_q15(&sp) < SPK_PROTECT_Q15_ONE,
+		      "%s: limiter engaged (gain %.3f)", label,
+		      spk_protect_gain_q15(&sp) / 32768.0);
+	} else {
+		CHECK(spk_protect_gain_q15(&sp) == SPK_PROTECT_Q15_ONE,
+		      "%s: static filters alone suffice (limiter idle)", label);
+	}
 }
 
 static void test_quiet_passthrough(void)
@@ -272,7 +288,9 @@ static void test_gain_ripple(void)
 {
 	printf("limiter ballistics (no per-cycle gain tracking):\n");
 
-	enum { N = FS }; /* 1 s of full-scale 200 Hz */
+	enum { N = FS }; /* 1 s of full-scale 500 Hz (engages under the
+			  * rebal voicing; 200 Hz no longer reaches the
+			  * budget after its deeper static cut) */
 	static int16_t buf[N];
 	struct spk_protect sp;
 	struct spk_protect_params p = params_default(1);
@@ -281,7 +299,7 @@ static void test_gain_ripple(void)
 	spk_protect_init(&sp, &p);
 
 	/* Settle 750 ms */
-	gen_sine(buf, N, 200, 1.0);
+	gen_sine(buf, N, 500, 1.0);
 	spk_protect_process(&sp, buf, (size_t)(0.75 * N));
 
 	/* Track gain across the following 200 ms, frame by frame */
@@ -301,8 +319,10 @@ static void test_gain_ripple(void)
 
 	double ripple = (double)(gmax - gmin) / gmax;
 
+	CHECK(gmax < SPK_PROTECT_Q15_ONE,
+	      "limiter engaged throughout the measurement window");
 	CHECK(gmin > 0 && ripple < 0.03,
-	      "gain ripple %.2f%% over steady 200 Hz (old limiter re-attacked every cycle)",
+	      "gain ripple %.2f%% over steady 500 Hz (old limiter re-attacked every cycle)",
 	      ripple * 100.0);
 }
 

--- a/tests/audio/speaker_protect/main.c
+++ b/tests/audio/speaker_protect/main.c
@@ -736,6 +736,106 @@ static void test_budget_drop(void)
 	      rms(buf + N / 2, N / 2));
 }
 
+static void test_peak_cap(void)
+{
+	printf("true-peak current clamp (fricative-spike regression, latched IC on HW):\n");
+
+	/* A pregain-boosted broadband onset from silence: the energy
+	 * sidechain is blind for ~env_ms, so without the cap the first
+	 * milliseconds pass at full boosted amplitude.
+	 */
+	enum { N = FS / 4 };
+	static int16_t buf[N], ref[N];
+	struct spk_protect sp;
+	struct spk_protect_params p = params_default(1);
+	uint32_t state = 0xCAFEBABEu;
+
+	p.ramp_ms = 0;
+	/* The hardware latch happened at budget 100: the energy limiter's
+	 * first-frame attack is weakest there, letting the onset emit ~4x
+	 * weighted before the integrator converges. Mirror that.
+	 */
+	p.budget_percent = 100;
+	p.peak_cap_percent = 300;
+
+	for (size_t i = 0; i < N; i++) {
+		state = state * 1664525u + 1013904223u;
+		/* silence, then a full-scale noise burst (fricative-ish) */
+		buf[i] = (i < N / 2) ? 0 : (int16_t)(state >> 16);
+	}
+	memcpy(ref, buf, sizeof(buf));
+
+	spk_protect_init(&sp, &p);
+	spk_protect_set_pregain(&sp, spk_protect_db10_to_q15(120)); /* +12 dB */
+	spk_protect_process(&sp, buf, N);
+
+	/* Reconstruct the weighted output amplitude sample by sample with
+	 * the independent sidechain's band split (per-sample |p|, no
+	 * integrator) and find the worst instantaneous excursion in the
+	 * onset window.
+	 */
+	struct ref_sidechain rc;
+
+	ref_sidechain_init(&rc, FS, p.env_ms);
+	double worst = 0;
+
+	for (size_t i = 0; i < N; i++) {
+		double x = buf[i], prev = 0, wsum = 0;
+
+		for (int b = 0; b < 6; b++) {
+			double band;
+
+			if (b < 5) {
+				rc.lp[b] += rc.alpha[b] * (x - rc.lp[b]);
+				band = rc.lp[b] - prev;
+				prev = rc.lp[b];
+			} else {
+				band = x - prev;
+			}
+			wsum += band * ref_weight[b];
+		}
+		if (i >= N / 2 && fabs(wsum) > worst) {
+			worst = fabs(wsum);
+		}
+	}
+
+	double cap = 32767.0 * 3.0; /* 300 % in weighted units */
+
+	CHECK(worst <= cap * 1.15,
+	      "boosted onset instantaneous weighted drive %.0f <= cap %.0f (x%.2f)",
+	      worst, cap, worst / cap);
+
+	struct spk_protect_stats st;
+
+	spk_protect_stats_read(&sp, &st, true);
+	CHECK(st.peak_capped_frames > 0,
+	      "clamp engaged on the onset (%u frames)", st.peak_capped_frames);
+
+	/* Below-cap content must be untouched: identical output with the
+	 * cap on and off.
+	 */
+	static int16_t a[FS / 4], b2[FS / 4];
+
+	for (size_t i = 0; i < N; i++) {
+		a[i] = (int16_t)lrint(0.4 * 32767.0 *
+				      sin(2.0 * PI * 700.0 * i / FS));
+	}
+	memcpy(b2, a, sizeof(a));
+
+	p = params_default(1);
+	p.ramp_ms = 0;
+	p.peak_cap_percent = 0;
+	spk_protect_init(&sp, &p);
+	spk_protect_process(&sp, a, N);
+
+	p.peak_cap_percent = 300;
+	spk_protect_init(&sp, &p);
+	spk_protect_process(&sp, b2, N);
+
+	CHECK(memcmp(a, b2, sizeof(a)) == 0,
+	      "normal content bit-exact with the cap enabled");
+}
+
 static void test_param_validation(void)
 {
 	printf("parameter validation:\n");
@@ -757,6 +857,9 @@ static void test_param_validation(void)
 	ok &= (spk_protect_init(&sp, &p) != 0);
 	p = params_default(1);
 	p.bass_drive_percent = 201;
+	ok &= (spk_protect_init(&sp, &p) != 0);
+	p = params_default(1);
+	p.peak_cap_percent = 1001;
 	ok &= (spk_protect_init(&sp, &p) != 0);
 
 	CHECK(ok, "invalid channels/budget/cutoff/rate/drive all rejected");
@@ -782,6 +885,7 @@ int main(void)
 	test_bass_enhancer_safety();
 	test_bass_enhancer_chunk_equivalence();
 	test_budget_drop();
+	test_peak_cap();
 	test_param_validation();
 
 	printf("\n%s (%d failure%s)\n", g_failures ? "FAILED" : "ALL TESTS PASSED",

--- a/tests/audio/speaker_protect/main.c
+++ b/tests/audio/speaker_protect/main.c
@@ -156,11 +156,16 @@ static double ref_sidechain_step(struct ref_sidechain *r, const int16_t *frame, 
 	return r->env;
 }
 
-static double budget_threshold(void)
+static double budget_threshold_pct(int budget)
 {
-	double amp = 32767.0 * BUDGET / 100.0;
+	double amp = 32767.0 * budget / 100.0;
 
 	return amp * amp / 2.0;
+}
+
+static double budget_threshold(void)
+{
+	return budget_threshold_pct(BUDGET);
 }
 
 /* ------------------------------------------------------------------ */
@@ -640,6 +645,97 @@ static void test_bass_enhancer_chunk_equivalence(void)
 	      "chunked output bit-exact with enhancer active");
 }
 
+static void test_budget_drop(void)
+{
+	printf("runtime budget drop (display-aware ducking):\n");
+
+	enum { N = FS }; /* 1 s blocks of full-scale 500 Hz (32-sample
+			  * period: regenerating the block continues the
+			  * phase seamlessly) */
+	static int16_t buf[N];
+	struct spk_protect sp;
+	struct spk_protect_params p = params_default(1);
+
+	spk_protect_init(&sp, &p);
+
+	/* Settle at the full budget */
+	gen_sine(buf, N, 500, 1.0);
+	spk_protect_process(&sp, buf, N);
+
+	double full_rms = rms(buf + N / 2, N / 2);
+	int32_t g0 = spk_protect_gain_q15(&sp);
+
+	/* Drop 20 points mid-stream; track per-frame gain steps through the
+	 * transition - the threshold slews over ~ramp_ms, so no single frame
+	 * may step the gain audibly (a click would be a large step).
+	 */
+	spk_protect_set_budget_drop(&sp, 20);
+	gen_sine(buf, N, 500, 1.0);
+
+	double max_step = 0;
+	int32_t g_prev = g0;
+
+	for (size_t i = 0; i < N; i++) {
+		spk_protect_process(&sp, &buf[i], 1);
+		int32_t g = spk_protect_gain_q15(&sp);
+		double step = fabs((double)(g - g_prev)) / g_prev;
+
+		if (step > max_step) {
+			max_step = step;
+		}
+		g_prev = g;
+	}
+
+	int32_t g1 = spk_protect_gain_q15(&sp);
+
+	CHECK(g1 < g0, "gain reduced after drop (%.3f -> %.3f)",
+	      g0 / 32768.0, g1 / 32768.0);
+	/* The limiter quantizes attacks to the env-ripple cycle, so single
+	 * frames legitimately step a fraction of a dB; a click would be tens
+	 * of percent. 3 % ~= 0.26 dB.
+	 */
+	CHECK(max_step < 0.03,
+	      "largest per-frame gain step %.2f%% (slewed, not stepped)",
+	      max_step * 100.0);
+
+	/* Settled energy now honours the reduced budget */
+	struct ref_sidechain ref;
+
+	ref_sidechain_init(&ref, FS, p.env_ms);
+
+	double max_env = 0;
+
+	for (size_t i = 0; i < N; i++) {
+		double env = ref_sidechain_step(&ref, &buf[i], 1);
+
+		if (i > (size_t)N / 2 && env > max_env) {
+			max_env = env;
+		}
+	}
+	CHECK(max_env <= budget_threshold_pct(BUDGET - 20) * 1.25,
+	      "settled energy honours budget %d (x%.2f of reduced threshold)",
+	      BUDGET - 20, max_env / budget_threshold_pct(BUDGET - 20));
+
+	/* Restoring the budget recovers the original level */
+	spk_protect_set_budget_drop(&sp, 0);
+	gen_sine(buf, N, 500, 1.0);
+	spk_protect_process(&sp, buf, N);
+
+	double back_rms = rms(buf + N / 2, N / 2);
+
+	CHECK(fabs(back_rms - full_rms) < 0.05 * full_rms,
+	      "output recovers after restore (RMS %.0f vs %.0f)",
+	      back_rms, full_rms);
+
+	/* Effective budget is floored: a huge drop must not mute entirely */
+	spk_protect_set_budget_drop(&sp, 95);
+	gen_sine(buf, N, 500, 1.0);
+	spk_protect_process(&sp, buf, N);
+	CHECK(rms(buf + N / 2, N / 2) > 0.01 * 32767.0,
+	      "5%% budget floor keeps audio audible (RMS %.0f)",
+	      rms(buf + N / 2, N / 2));
+}
+
 static void test_param_validation(void)
 {
 	printf("parameter validation:\n");
@@ -685,6 +781,7 @@ int main(void)
 	test_bass_enhancer();
 	test_bass_enhancer_safety();
 	test_bass_enhancer_chunk_equivalence();
+	test_budget_drop();
 	test_param_validation();
 
 	printf("\n%s (%d failure%s)\n", g_failures ? "FAILED" : "ALL TESTS PASSED",


### PR DESCRIPTION
# Speaker loudness and protection-envelope enhancements

Reworks the speaker output chain around bench current calibration: louder,
clearer speech inside the same battery-protection envelope, plus a
per-stream API that lets applications choose their loudness/current
trade-off for playback that needs it (the immediate case: TTS that cannot
be normalized at source).

## Voicing and calibration

- **Loudness-rebalanced voicing** (`-18/-15/-10/-4/0/+4` dB across the six
  bands) with the protection HPF at **200 Hz**: current is reallocated from
  the vibrotactile lows toward the audible bands. Chosen by blinded on-head
  A/B at matched volume — louder speech at equal perceived buzz, with
  limiter engagement on full-volume speech dropping from ~40 % to ~25 % of
  frames.
- **Sidechain current weights recalibrated from bench measurements**
  (tones through the full chain at 3.7 V, PSU + ammeter). Once the old
  voicing's per-band attenuation is factored out, supply current tracks
  drive **amplitude**, not frequency (flat within a few percent,
  150 Hz–2 kHz, following `I ≈ 1550 mA · A_rms^1.8`). The weights are now
  **uniform 3.0**, so the energy budget caps current honestly for any
  spectrum at either sample rate. The previous low-band-heavy table was an
  artifact of the inverted-EQ heuristic it was derived from.
- Budget 80 (the shipped default) anchors to the measured safe ceiling:
  ~72 mA audio above baseline, keeping the per-pack share plus quiescent
  system load under the battery IC's minimum over-discharge trip with the
  display in power save. Bench re-verification after the change: full-scale
  clamp ceilings are flat across frequency at that level.

## Per-stream playback API

Two new optional `frame.speaker.start{}` fields, both transient (cleared
on every speaker acquisition, so they cannot leak between owners):

| field | range | effect |
|---|---|---|
| `gain` | 0–12 dB | digital pre-gain into the protection limiter: lifts quiet sources toward the loudness ceiling, compresses hot ones; the sidechain sees the boosted signal, so the current budget still caps real transducer drive |
| `budget` | 10–100 | per-stream energy-budget override, clamped to `MAX98357A_AUDIO_PROTECT_STREAM_BUDGET_MAX` (default 100); higher = louder ceiling at more battery current |

Any budget override also selects a **fast 1 ms sidechain integration
window** (`MAX98357A_AUDIO_PROTECT_STREAM_BUDGET_ENV_MS`). Bench
characterisation showed the battery IC's effective trip window is a few
milliseconds, and broadband speech onsets (fricatives) under high pre-gain
can accumulate that exposure while the default 3 ms envelope converges;
the fast window clamps them ~3× sooner. With it, the maximum envelope
(`budget=100, gain=12`) is bench-validated against worst-case content —
full-scale speech at maximum volume — on a low-trip-sample unit. At
requested budgets below the default the fast window is harmlessly
conservative. No raw DSP knobs (weights, limiter internals) are exposed.

## Display-aware budget

The display's supply current rides the same battery-protection IC as the
speakers, so the chain now **ducks its energy budget while the display is
out of power save** (`MAX98357A_AUDIO_PROTECT_DISPLAY_BUDGET_DROP`,
default 20 points) and restores it when the display sleeps. The change is
a smooth ramped step even mid-stream, ordered so the duck lands **before**
the panel starts drawing (and the restore only after the load is gone) —
the combined load can never overshoot either steady state. Composes with
per-stream budget overrides.

Audible consequence, deliberate: content played with the display on sits
up to ~2 dB below the display-off loudness ceiling. Applications wanting
full speech loudness should blank the display during playback.

## Protection improvements

- **True-peak clamp** on the current-weighted output amplitude
  (`MAX98357A_AUDIO_PROTECT_PEAK_CAP_PERCENT`, default 300 %): a
  single-sample backstop against tall transients (e.g. decoder garbage)
  inside the envelope's integration window. Engages 0 frames on normal
  content; below-cap content is bit-exact.
- **Limiter releases upward when its budget rises mid-clamp** — previously
  the gain ratcheted down and only recovered when the content itself went
  quiet, so a budget restore (display sleeping) during continuous audio
  never took effect.
- Runtime tuning API for bench/listening builds
  (`MAX98357A_AUDIO_PROTECT_TUNING`, default off — compiled out of
  production images).
- Psychoacoustic bass enhancer stage in the chain (recovers perceived
  fullness of the HPF-removed lows via generated harmonics), compiled in
  but **disabled by default** (`MAX98357A_AUDIO_BASS_ENHANCE_PERCENT=0`;
  enable via Kconfig after on-head tuning of the felt-vibration
  trade-off). Host-tested for harmonic generation, budget safety and
  chunked bit-exactness.

## Testing

- Host suite (`tests/audio/speaker_protect`, ASan/UBSan) extended:
  budget-drop slew and recovery, true-peak clamp regression mirroring the
  bench transient case, pre-gain, enhancer, chunked bit-exactness — all
  green.
- Bench (PSU + ammeter, dev kit): frequency/level/budget maps match the
  calibration model within a few mA; display toggle verified smooth in
  both directions on the production stream path.
- On-head (production unit): blinded 6-trial A/B of the new voicing
  (+1 loudness point at equal buzz), display on/off deltas as designed,
  gain ladder exact (+6/+12 dB delivered uncompressed on quiet sources),
  and a display-on full-volume speech endurance run with no
  battery-protection events.
- Real TTS (production voice, streamed over the BLE audio path):
  normalization + `gain`/`budget` recipe verified; the API delivers the
  intended loudness range with all protection active.

## Compatibility

- Default playback gets the new voicing (noticeably louder speech at the
  same settings); no API changes required to benefit.
- `frame.speaker.start{}` accepts the new optional fields; existing
  callers are unaffected.
- Kconfig defaults changed: `PROTECT_HPF_HZ` 130 → 200; new symbols
  `PROTECT_PEAK_CAP_PERCENT`, `PROTECT_DISPLAY_BUDGET_DROP`,
  `PROTECT_STREAM_BUDGET_MAX`, `PROTECT_STREAM_BUDGET_ENV_MS`. A pristine
  build is required for the new defaults to take effect.
