### PR TITLE
ble_lua: refuse offset and zero-length RX writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,15 @@ release pages and tags are not publicly reachable.
 - Speaker limiter releases upward when its budget rises mid-clamp
   (previously the gain ratcheted down until the content itself went
   quiet)
+- BLE Lua RX and audio-RX characteristics refuse ATT offset (long/prepared)
+  writes (`NO_OFFSET`), matching the rest of the GATT database; one ATT write
+  is treated as one complete message (#7)
+
+### Fixed
+
+- BLE Lua RX write handler no longer underflows the ring-buffer length on a
+  zero-length or offset write, and continuation fragments no longer drop a
+  byte or gain a stray newline (#7)
 
 ## [0.8.8] - 2026-08-17
 

--- a/applications/halo/tests/test_ble_rx_write.py
+++ b/applications/halo/tests/test_ble_rx_write.py
@@ -1,0 +1,122 @@
+# /// script
+# requires-python = ">=3.10,<3.14"
+# dependencies = ["brilliant-ble>=3.1.1,<4"]
+# ///
+"""
+On-device regression test for the Lua RX GATT write handler
+(modules/halo/src/ble_lua.c). Runs unattended on a dev kit (Halo AB).
+
+It exercises the edge cases the write handler must survive and frame
+correctly, writing raw bytes straight to the RX characteristic so it can
+reach paths the SDK's own send_lua()/send_data() never produce:
+
+  1. Baseline: a normal statement round-trips.
+  2. A zero-length write is a harmless no-op and the device stays responsive.
+  3. A burst of zero-length writes does not wedge or crash the device.
+  4. A within-MTU statement executes as exactly one line (no lost byte, no
+     spurious interior newline) - proven by evaluating an arithmetic
+     expression whose printed result would change if a byte were dropped.
+  5. An over-MTU single write (an ATT long/prepared write) is refused now
+     that the characteristic sets NO_OFFSET; the device must survive and
+     stay responsive whether the stack reports an error or drops it.
+
+Usage:
+    uv run test_ble_rx_write.py [--name "Halo AB"]
+
+Exit code 0 = all checks passed.
+"""
+
+import argparse
+import asyncio
+
+from brilliant_ble import BrilliantBle
+
+FAILURES = []
+
+
+def check(cond, label):
+    print(f"  {'PASS' if cond else 'FAIL'}: {label}")
+    if not cond:
+        FAILURES.append(label)
+
+
+async def rx_raw_write(b, payload, response=True):
+    """Write raw bytes to the device RX characteristic, bypassing the SDK's
+    length guard. Returns None on success or the exception on failure."""
+    try:
+        await b._client.write_gatt_char(b._tx_characteristic, payload, response=response)
+        return None
+    except Exception as exc:  # noqa: BLE001 - we want to observe, not raise
+        return exc
+
+
+async def responsive(b):
+    """True if the device still evaluates a REPL statement and prints back."""
+    try:
+        token = await b.send_lua("print('alive_'..tostring(2*21))", await_print=True, timeout=5)
+        return token is not None and "alive_42" in token
+    except Exception:
+        return False
+
+
+async def main():
+    parser = argparse.ArgumentParser(
+        description="Connect to a Halo/Frame dev kit over BLE and run the RX write regression test."
+    )
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
+
+    b = BrilliantBle()
+    name = await b.connect(name=args.name, print_response_handler=lambda s: None)
+    # The device boots into main.lua, which prints to the same channel as REPL
+    # responses. Flush any stray app output so the first await_print below
+    # reads a REPL reply and not an app line.
+    await b.drain_print_channel()
+    fw = await b.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+    mtu = b._client.mtu_size
+    print(f"{name} | firmware {fw} | MTU {mtu}")
+
+    # 1. Baseline round-trip.
+    check(await responsive(b), "baseline statement round-trips")
+
+    # 2. Single zero-length write is a no-op; device stays responsive.
+    err = await rx_raw_write(b, b"")
+    check(await responsive(b), "device responsive after a zero-length write")
+
+    # 3. Burst of zero-length writes does not wedge the device.
+    for _ in range(20):
+        await rx_raw_write(b, b"", response=False)
+    await asyncio.sleep(0.2)
+    check(await responsive(b), "device responsive after 20 zero-length writes")
+
+    # 4. A within-MTU statement executes as exactly one line. The expression
+    #    is chosen so a dropped byte or an injected newline changes the result
+    #    (or makes it error out and print nothing).
+    stmt = "print('sum='..tostring(111+222+333))"
+    assert len(stmt) <= mtu - 3, "statement must fit one packet for this check"
+    got = await b.send_lua(stmt, await_print=True, timeout=5)
+    check(got is not None and "sum=666" in got,
+          f"within-MTU statement is one clean line (got {got!r})")
+
+    # 5. Over-MTU single write is refused (NO_OFFSET). Build a payload larger
+    #    than one packet so the stack would have to long-write it.
+    big = b"print('X" + b"y" * (mtu + 40) + b"')"
+    err = await rx_raw_write(b, big, response=True)
+    outcome = "rejected by stack" if err is not None else "accepted/dropped by controller"
+    print(f"    over-MTU write: {outcome}")
+    check(await responsive(b), "device responsive after an over-MTU write")
+
+    await b.disconnect()
+
+    print()
+    if FAILURES:
+        print(f"FAILED ({len(FAILURES)}): " + "; ".join(FAILURES))
+        raise SystemExit(1)
+    print("OK")
+
+
+asyncio.run(main())

--- a/modules/halo/src/ble_lua.c
+++ b/modules/halo/src/ble_lua.c
@@ -81,7 +81,6 @@ struct ble_lua_ctx {
 	uint8_t *data_rx_buf;
 	struct ring_buf data_rx_ring;
 	struct k_sem data_rx_sem;
-	struct ring_buf *current_rx_ring; /* Points to current active ring */
 
 	/* Audio ring buffer */
 	uint8_t *audio_rx_buf;
@@ -132,7 +131,7 @@ static const gatt_att_desc_t lua_att_db[LUA_IDX_NB] = {
 	[LUA_IDX_RX_CHAR] = {ATT_128_CHARACTERISTIC, ATT_UUID(16) | PROP(RD), 0},
 	[LUA_IDX_RX_VAL] = {HALO_LUA_UUID_128_RX,
 			    ATT_UUID(128) | PROP(WC) | PROP(WR) | SEC_LVL(WP, UNAUTH),
-			    CFG_ATT_VAL_MAX},
+			    OPT(NO_OFFSET) | CFG_ATT_VAL_MAX},
 
 	/* TX Characteristic */
 	[LUA_IDX_TX_CHAR] = {ATT_128_CHARACTERISTIC, ATT_UUID(16) | PROP(RD), 0},
@@ -154,7 +153,7 @@ static const gatt_att_desc_t lua_att_db[LUA_IDX_NB] = {
 	[LUA_IDX_AUDIO_RX_CHAR] = {ATT_128_CHARACTERISTIC, ATT_UUID(16) | PROP(RD), 0},
 	[LUA_IDX_AUDIO_RX_VAL] = {HALO_LUA_UUID_128_AUDIO_RX,
 				  ATT_UUID(128) | PROP(WC) | PROP(WR) | SEC_LVL(WP, UNAUTH),
-				  CFG_ATT_VAL_MAX},
+				  OPT(NO_OFFSET) | CFG_ATT_VAL_MAX},
 
 	/* Audio TX Characteristic */
 	[LUA_IDX_AUDIO_TX_CHAR] = {ATT_128_CHARACTERISTIC, ATT_UUID(16) | PROP(RD), 0},
@@ -238,78 +237,73 @@ static void on_att_val_set(uint8_t conidx, uint8_t user_lid, uint16_t token, uin
 
 	switch (att_idx) {
 	case LUA_IDX_RX_VAL: {
-		struct ring_buf *target_ring;
-		struct k_sem *target_sem;
-
 		if (halo_ble_is_paired() == false) {
 			LOG_WRN("Write attempt while not paired - rejected");
 			status = ATT_ERR_INSUFF_AUTHEN;
 			break;
 		}
 
-		/* Handle control commands and data routing */
-		if (offset == 0 && len > 0) {
-			/* Check for control commands */
-			if (data[0] == HALO_LUA_CTRL_REBOOT ||
-			    data[0] == HALO_LUA_CTRL_INTERRUPT ||
-			    data[0] == HALO_LUA_CTRL_RESTART || data[0] == HALO_LUA_CTRL_RESET ||
-			    data[0] == HALO_LUA_CTRL_EXIT || data[0] == HALO_LUA_CTRL_REMOVE_ALL) {
-				// clear REPL buffer
-				ring_buf_reset(&lua_ctx.repl_rx_ring);
-				// clear Data buffer
-				ring_buf_reset(&lua_ctx.data_rx_ring);
-				if (lua_ctx.ctrl_handler) {
-					lua_ctx.ctrl_handler(data[0]);
-				}
-				break;
-			}
-
-			/* Route to data or REPL ring buffer */
-			if (data[0] == HALO_LUA_CTRL_DATA_MARKER && len >= 2) {
-				target_ring = &lua_ctx.data_rx_ring;
-				target_sem = &lua_ctx.data_rx_sem;
-			} else {
-				target_ring = &lua_ctx.repl_rx_ring;
-				target_sem = &lua_ctx.repl_rx_sem;
-				len++; // reserve for '\n'
-			}
-		} else {
-			/* Continuation of previous write - use last selected ring */
-			if (lua_ctx.current_rx_ring == &lua_ctx.data_rx_ring) {
-				target_ring = &lua_ctx.data_rx_ring;
-				target_sem = &lua_ctx.data_rx_sem;
-			} else {
-				target_ring = &lua_ctx.repl_rx_ring;
-				target_sem = &lua_ctx.repl_rx_sem;
-			}
-		}
-
-		/* Update current ring for next continuation */
-		lua_ctx.current_rx_ring = target_ring;
-
-		/* Check buffer space */
-		if (ring_buf_space_get(target_ring) < len) {
-			LOG_WRN("RX ring buffer full (available=%u, needed=%u)",
-				ring_buf_space_get(target_ring), len);
-			status = ATT_ERR_INSUFF_RESOURCE;
+		/* NO_OFFSET is set on this attribute, so the controller refuses any
+		 * offset (long/prepared) write before it reaches us and offset is
+		 * always 0. One ATT write is therefore one complete message: a REPL
+		 * statement or one framed data payload. Reject a stray offset
+		 * defensively in case the attribute config ever changes - there is
+		 * no end-of-write signal here to reassemble a fragmented write. */
+		if (offset != 0) {
+			LOG_WRN("Offset write on RX rejected (offset=%u)", offset);
+			status = ATT_ERR_INVALID_OFFSET;
 			break;
 		}
 
-		/* Store data */
-		if (target_ring == &lua_ctx.repl_rx_ring) {
-			/* REPL: add data as-is */
-			ring_buf_put(target_ring, data, len - 1);
-			uint8_t newline = '\n';
-			ring_buf_put(target_ring, &newline, 1);
-			k_sem_give(target_sem);
-		} else {
-			/* Data: skip first byte (marker) on first write */
-			if (offset == 0 && data[0] == HALO_LUA_CTRL_DATA_MARKER) {
-				ring_buf_put(target_ring, data + 1, len - 1);
-			} else {
-				ring_buf_put(target_ring, data, len);
+		/* A zero-length write carries no command - ignore it. Guarding here
+		 * also keeps the len-based sizing below away from unsigned
+		 * underflow. */
+		if (len == 0) {
+			break;
+		}
+
+		/* Control commands */
+		if (data[0] == HALO_LUA_CTRL_REBOOT ||
+		    data[0] == HALO_LUA_CTRL_INTERRUPT ||
+		    data[0] == HALO_LUA_CTRL_RESTART || data[0] == HALO_LUA_CTRL_RESET ||
+		    data[0] == HALO_LUA_CTRL_EXIT || data[0] == HALO_LUA_CTRL_REMOVE_ALL) {
+			// clear REPL buffer
+			ring_buf_reset(&lua_ctx.repl_rx_ring);
+			// clear Data buffer
+			ring_buf_reset(&lua_ctx.data_rx_ring);
+			if (lua_ctx.ctrl_handler) {
+				lua_ctx.ctrl_handler(data[0]);
 			}
-			k_sem_give(target_sem);
+			break;
+		}
+
+		if (data[0] == HALO_LUA_CTRL_DATA_MARKER && len >= 2) {
+			/* Framed data: store the payload after the marker byte. */
+			uint16_t payload_len = len - 1;
+
+			if (ring_buf_space_get(&lua_ctx.data_rx_ring) < payload_len) {
+				LOG_WRN("Data RX ring full (available=%u, needed=%u)",
+					ring_buf_space_get(&lua_ctx.data_rx_ring), payload_len);
+				status = ATT_ERR_INSUFF_RESOURCE;
+				break;
+			}
+			ring_buf_put(&lua_ctx.data_rx_ring, data + 1, payload_len);
+			k_sem_give(&lua_ctx.data_rx_sem);
+		} else {
+			/* REPL: one write is one line - store it and append a single
+			 * '\n' terminator that the runtime splits on. */
+			uint32_t needed = (uint32_t)len + 1;
+
+			if (ring_buf_space_get(&lua_ctx.repl_rx_ring) < needed) {
+				LOG_WRN("REPL RX ring full (available=%u, needed=%u)",
+					ring_buf_space_get(&lua_ctx.repl_rx_ring), needed);
+				status = ATT_ERR_INSUFF_RESOURCE;
+				break;
+			}
+			ring_buf_put(&lua_ctx.repl_rx_ring, data, len);
+			uint8_t newline = '\n';
+			ring_buf_put(&lua_ctx.repl_rx_ring, &newline, 1);
+			k_sem_give(&lua_ctx.repl_rx_sem);
 		}
 		break;
 	}
@@ -341,6 +335,13 @@ static void on_att_val_set(uint8_t conidx, uint8_t user_lid, uint16_t token, uin
 		if (halo_ble_is_paired() == false) {
 			LOG_WRN("Audio write attempt while not paired - rejected");
 			status = ATT_ERR_INSUFF_AUTHEN;
+			break;
+		}
+		/* NO_OFFSET is set on this attribute; reject a stray offset write
+		 * defensively (mirrors RX_VAL). */
+		if (offset != 0) {
+			LOG_WRN("Offset write on audio RX rejected (offset=%u)", offset);
+			status = ATT_ERR_INVALID_OFFSET;
 			break;
 		}
 		/* Store audio input data */
@@ -557,7 +558,6 @@ int halo_ble_lua_init(bool reset)
 		lua_ctx.tx_ccc_cfg = 0;
 		lua_ctx.video_ccc_cfg = 0;
 		lua_ctx.audio_tx_ccc_cfg = 0;
-		lua_ctx.current_rx_ring = NULL;
 		lua_ctx.ctrl_handler = NULL;
 		lua_ctx.user_lid = GATT_INVALID_USER_LID;
 		lua_ctx.start_hdl = GATT_INVALID_HDL;

--- a/tests/bluetooth/ble_lua_rx/.gitignore
+++ b/tests/bluetooth/ble_lua_rx/.gitignore
@@ -1,0 +1,3 @@
+ble_lua_rx_test
+ble_lua_rx_repro
+*.dSYM/

--- a/tests/bluetooth/ble_lua_rx/Makefile
+++ b/tests/bluetooth/ble_lua_rx/Makefile
@@ -1,0 +1,31 @@
+# Host-side reproduction/regression test for the Lua RX GATT write handler
+# (modules/halo/src/ble_lua.c). Transcribes the handler with a faithful
+# ring_buf stand-in and drives it under ASan/UBSan.
+#
+#   make run    - production logic; all checks pass (exit 0)
+#   make repro  - pre-fix logic; ASan aborts on the length underflow
+
+CFLAGS := -std=c99 -O1 -g -Wall -Wextra -Werror \
+          -fsanitize=address,undefined -fno-sanitize-recover=all
+
+ble_lua_rx_test: main.c
+	$(CC) $(CFLAGS) -o $@ $<
+
+ble_lua_rx_repro: main.c
+	$(CC) $(CFLAGS) -DVULNERABLE -o $@ $<
+
+.PHONY: run repro clean
+run: ble_lua_rx_test
+	./ble_lua_rx_test
+
+# Demonstrates the pre-fix bug: expected to abort under AddressSanitizer,
+# so a clean (non-aborting) exit here is itself a failure.
+repro: ble_lua_rx_repro
+	@if ./ble_lua_rx_repro; then \
+		echo "UNEXPECTED: pre-fix build did not abort"; exit 1; \
+	else \
+		echo "expected AddressSanitizer abort observed"; \
+	fi
+
+clean:
+	rm -rf ble_lua_rx_test ble_lua_rx_repro *.dSYM

--- a/tests/bluetooth/ble_lua_rx/README.md
+++ b/tests/bluetooth/ble_lua_rx/README.md
@@ -1,0 +1,43 @@
+# ble_lua RX write-handler tests
+
+Host-side (macOS/Linux) reproduction and regression test for the Lua RX GATT
+write handler in `modules/halo/src/ble_lua.c` (`on_att_val_set`,
+`LUA_IDX_RX_VAL` / `LUA_IDX_AUDIO_RX_VAL`).
+
+```sh
+make run     # production logic: all checks pass (exit 0)
+make repro   # pre-fix logic: AddressSanitizer aborts on the underflow
+```
+
+## What it covers
+
+The handler body is transcribed into `main.c` and driven with the
+`(offset, data, len)` triples an ATT write hands the callback. Each payload
+lives in a heap buffer of **exactly** `len` bytes, and a faithful stand-in for
+Zephyr's `ring_buf_put` reproduces its one load-bearing property — it copies
+`MIN(size, free)` bytes and reads them from the source pointer. Compiled with
+ASan + UBSan, so an over-read is caught rather than silently tolerated.
+
+- Zero-length write (REPL and data current ring) stores nothing.
+- A REPL statement arrives as exactly one `\n`-terminated line — no lost byte,
+  no spurious interior newline.
+- An offset (long-write) fragment is refused with `ATT_ERR_INVALID_OFFSET` and
+  leaves no partial state.
+- A framed data write stores the payload with the `0x01` marker stripped.
+- An unpaired write is rejected.
+
+`make repro` builds the pre-fix logic (`-DVULNERABLE`, `main` @ b4f0dcd): a
+zero-length continuation write reaches `ring_buf_put(ring, data, len - 1)` with
+`len == 0`, so `len - 1` promotes to `0xFFFFFFFF` and the copy drains the
+ring's free space out of a zero-length source. The target aborts under
+AddressSanitizer; a clean exit is treated as a test failure.
+
+## Scope
+
+This is a fast, hardware-free guard on the length arithmetic and routing. It
+transcribes the handler rather than compiling it (the production function pulls
+in the Alif GATT stack, `co_buf`, and `k_sem`), so it does not prove the
+transcription stays in step with the source. Whether the Alif ROM actually
+forwards a zero-length write or an offset write to the callback in the first
+place is an end-to-end question covered on a dev kit by
+`applications/halo/tests/test_ble_rx_write.py`.

--- a/tests/bluetooth/ble_lua_rx/VALIDATION.md
+++ b/tests/bluetooth/ble_lua_rx/VALIDATION.md
@@ -1,0 +1,72 @@
+# Validating the ble_lua RX write-handler fix
+
+What changed: `LUA_IDX_RX_VAL` and `LUA_IDX_AUDIO_RX_VAL` now set `NO_OFFSET`,
+and `on_att_val_set` refuses offset writes, ignores zero-length writes, no
+longer mutates `len`, and appends exactly one `\n` per REPL write. The dropped
+continuation state machine (`current_rx_ring`) is gone. This is a behaviour
+change on two public characteristics, so the point of this sweep is to prove
+the normal REPL, data, and audio write paths still work.
+
+## 1. Host unit test (no hardware)
+
+```sh
+cd tests/bluetooth/ble_lua_rx
+make run      # production logic: all checks pass
+make repro    # pre-fix logic: AddressSanitizer aborts on the underflow
+```
+
+## 2. On-device edge cases (Halo AB, unattended)
+
+```sh
+cd applications/halo/tests
+uv run test_ble_rx_write.py --name "Halo AB"
+```
+
+Covers zero-length writes, a zero-length burst, single-line framing, and an
+over-MTU (long) write being refused while the device stays responsive.
+
+## 3. SDK regression sweep (Halo AB, unattended)
+
+From the SDK checkout, package dir
+`python/packages/brilliant_ble`. Standalone scripts run with `uv run`; the
+host-only chunking test runs under pytest.
+
+Data / RX-write path (the paths this change touches most):
+
+```sh
+uv run tests/test_file_api.py --name "Halo AB"            # send_data file writes
+uv run tests/test_file_execution.py --name "Halo AB"      # upload + execute
+uv run tests/test_compression.py --name "Halo AB"         # send_data + compression
+uv run tests/test_bluetooth_callback_api.py --name "Halo AB"  # send_data round-trip
+uv run --with pytest pytest tests/test_chunk_lua_string.py    # host-only, chunking
+```
+
+REPL (`send_lua`) smoke — bounded, judge by exit code:
+
+```sh
+uv run tests/test_text_api.py --name "Halo AB"    # argument validation, asserts
+uv run tests/test_version.py --name "Halo AB"
+uv run tests/test_time.py --name "Halo AB"
+uv run tests/test_display.py --name "Halo AB"
+uv run tests/test_display_bitmap.py --name "Halo AB"
+```
+
+Streaming / monitor tests — these keep the connection open and print until
+interrupted, so under a timeout they exit 124 *by design*. Judge them by
+whether they connect and stream, not by exit code:
+
+```sh
+uv run tests/test_aad.py --name "Halo AB"            # idles waiting for sound
+uv run tests/test_imu_direction.py --name "Halo AB"  # streams roll/pitch/heading
+uv run tests/test_imu_raw.py --name "Halo AB"        # streams accel/compass
+```
+
+## Excluded — need a human, an observer, or a rig
+
+`test_bluetooth_throughput` (waits on Enter), `test_camera` (waits on Enter +
+image review), `test_button`, `test_taps` (physical input),
+`test_speaker_pcm` / `test_speaker_lc3` / `test_speaker_lc3_2` (need a
+listener), `test_microphone` / `test_microphone_lc3` (need sound to verify).
+The speaker/mic scripts still make a good manual check that the audio RX/TX
+characteristics survive `NO_OFFSET`, since `send_audio` writes to
+`LUA_IDX_AUDIO_RX_VAL`.

--- a/tests/bluetooth/ble_lua_rx/main.c
+++ b/tests/bluetooth/ble_lua_rx/main.c
@@ -1,0 +1,240 @@
+/* Copyright (c) 2026 Brilliant Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Host-side reproduction and regression test for the Lua RX GATT write
+ * handler (modules/halo/src/ble_lua.c, LUA_IDX_RX_VAL / LUA_IDX_AUDIO_RX_VAL).
+ *
+ * The handler body is transcribed here and driven with the
+ * (offset, data, len) triples an ATT write hands the callback. Each payload
+ * is placed in a heap buffer of *exactly* len bytes, so a copy that reads
+ * past it is caught by AddressSanitizer instead of silently tolerated. A
+ * faithful stand-in for Zephyr's ring_buf_put reproduces its defining
+ * property: it copies MIN(size, free) bytes and reads them from the source
+ * pointer.
+ *
+ * Two builds, selected by -DVULNERABLE:
+ *   make run    - production logic; every check must PASS (exit 0).
+ *   make repro  - pre-fix logic; AddressSanitizer aborts in the zero-length
+ *                 case, demonstrating the length underflow the fix removes.
+ *
+ * This is a fast, hardware-free guard on the length arithmetic and routing.
+ * End-to-end behaviour against real firmware (whether the ROM forwards a
+ * zero-length write or an offset write to the callback at all) is covered by
+ * applications/halo/tests/test_ble_rx_write.py on a dev kit.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+/* --- ring_buf stand-in --------------------------------------------------- *
+ * The bug depends on exactly one ring_buf_put property: it copies
+ * MIN(size, free) bytes and READS them from `src`. With size == 0xFFFFFFFF
+ * (from a uint16 `len - 1` at len == 0) that is `free` bytes out of a
+ * zero-length source - the out-of-bounds read this test exists to catch. */
+struct ring {
+	uint8_t *buf;
+	uint32_t cap, len;
+};
+static void ring_init(struct ring *r, uint32_t cap)
+{
+	r->buf = malloc(cap);
+	r->cap = cap;
+	r->len = 0;
+}
+static uint32_t ring_buf_space_get(const struct ring *r) { return r->cap - r->len; }
+static void ring_buf_reset(struct ring *r) { r->len = 0; }
+static uint32_t ring_buf_put(struct ring *r, const uint8_t *src, uint32_t size)
+{
+	uint32_t space = ring_buf_space_get(r);
+	uint32_t n = size < space ? size : space; /* MIN(size, free) */
+	memcpy(r->buf + r->len, src, n);          /* reads n bytes from src   */
+	r->len += n;
+	return n;
+}
+
+/* markers, mirrored from modules/halo/include/halo/ble_lua.h */
+#define HALO_LUA_CTRL_DATA_MARKER 0x01
+#define HALO_LUA_CTRL_REBOOT      0x04
+#define REPL_CAP 1024
+#define DATA_CAP 4096
+
+static struct ring g_repl, g_data;
+#ifdef VULNERABLE
+static struct ring *g_current; /* the pre-fix continuation state machine */
+#endif
+static bool g_paired = true;
+
+/* Transcription of the LUA_IDX_RX_VAL case body. Returns an ATT status; the
+ * newline is folded into the REPL store exactly as the handler does. */
+static int rx_write(uint16_t offset, const uint8_t *data, uint16_t len)
+{
+	if (!g_paired) {
+		return 0x05; /* ATT_ERR_INSUFF_AUTHEN */
+	}
+
+#ifndef VULNERABLE
+	/* --- production logic ------------------------------------------- */
+	if (offset != 0) {
+		return 0x07; /* ATT_ERR_INVALID_OFFSET */
+	}
+	if (len == 0) {
+		return 0x00;
+	}
+	if (data[0] == HALO_LUA_CTRL_REBOOT) {
+		ring_buf_reset(&g_repl);
+		ring_buf_reset(&g_data);
+		return 0x00;
+	}
+	if (data[0] == HALO_LUA_CTRL_DATA_MARKER && len >= 2) {
+		uint16_t payload_len = len - 1;
+		if (ring_buf_space_get(&g_data) < payload_len) {
+			return 0x11; /* ATT_ERR_INSUFF_RESOURCE */
+		}
+		ring_buf_put(&g_data, data + 1, payload_len);
+	} else {
+		uint32_t needed = (uint32_t)len + 1;
+		if (ring_buf_space_get(&g_repl) < needed) {
+			return 0x11;
+		}
+		ring_buf_put(&g_repl, data, len);
+		uint8_t nl = '\n';
+		ring_buf_put(&g_repl, &nl, 1);
+	}
+	return 0x00;
+#else
+	/* --- pre-fix logic (main @ b4f0dcd) ----------------------------- */
+	struct ring *target_ring;
+	if (offset == 0 && len > 0) {
+		if (data[0] == HALO_LUA_CTRL_REBOOT) {
+			ring_buf_reset(&g_repl);
+			ring_buf_reset(&g_data);
+			return 0x00;
+		}
+		if (data[0] == HALO_LUA_CTRL_DATA_MARKER && len >= 2) {
+			target_ring = &g_data;
+		} else {
+			target_ring = &g_repl;
+			len++; /* reserve for '\n' */
+		}
+	} else {
+		target_ring = (g_current == &g_data) ? &g_data : &g_repl;
+	}
+	g_current = target_ring;
+	if (ring_buf_space_get(target_ring) < len) {
+		return 0x11;
+	}
+	if (target_ring == &g_repl) {
+		ring_buf_put(target_ring, data, len - 1); /* underflow at len==0 */
+		uint8_t nl = '\n';
+		ring_buf_put(target_ring, &nl, 1);
+	} else {
+		if (offset == 0 && data[0] == HALO_LUA_CTRL_DATA_MARKER) {
+			ring_buf_put(target_ring, data + 1, len - 1);
+		} else {
+			ring_buf_put(target_ring, data, len);
+		}
+	}
+	return 0x00;
+#endif
+}
+
+/* Hand rx_write a buffer of EXACTLY len bytes so any over-read is real. */
+static int att_write(uint16_t offset, const void *bytes, uint16_t len)
+{
+	uint8_t *p = malloc(len ? len : 1);
+	if (len) memcpy(p, bytes, len);
+	int rc = rx_write(offset, p, len);
+	free(p);
+	return rc;
+}
+
+static int g_fail;
+#define CHECK(cond, ...)                                                       \
+	do {                                                                   \
+		printf((cond) ? "  PASS: " : "  FAIL: ");                       \
+		printf(__VA_ARGS__);                                            \
+		printf("\n");                                                   \
+		if (!(cond)) g_fail++;                                          \
+	} while (0)
+
+static void reset_all(void)
+{
+	ring_buf_reset(&g_repl);
+	ring_buf_reset(&g_data);
+#ifdef VULNERABLE
+	g_current = NULL;
+#endif
+}
+
+static const char *repl_str(char *out, size_t cap)
+{
+	uint32_t n = g_repl.len < cap ? g_repl.len : (uint32_t)cap - 1;
+	memcpy(out, g_repl.buf, n);
+	out[n] = 0;
+	return out;
+}
+
+int main(void)
+{
+	ring_init(&g_repl, REPL_CAP);
+	ring_init(&g_data, DATA_CAP);
+	char got[128];
+
+#ifdef VULNERABLE
+	printf("[pre-fix build - expect an AddressSanitizer abort]\n");
+#else
+	printf("[production build]\n");
+#endif
+
+	/* 1. Zero-length write, REPL current. Pre-fix: len-1 == 0xFFFFFFFF
+	 *    drains REPL_CAP bytes out of a zero-length source (ASan aborts). */
+	reset_all();
+	att_write(0, "print()", 7);
+	uint32_t repl_before = g_repl.len;
+	att_write(1, "", 0);
+	CHECK(g_repl.len == repl_before, "zero-length write stores nothing");
+
+	/* 2. Zero-length write, DATA current. */
+	reset_all();
+	att_write(0, "\x01Q", 2);
+	uint32_t data_before = g_data.len;
+	att_write(1, "", 0);
+	CHECK(g_data.len == data_before, "zero-length data write stores nothing");
+
+	/* 3. A single REPL statement arrives as exactly one '\n'-terminated
+	 *    line - no lost byte, no spurious interior newline. */
+	reset_all();
+	att_write(0, "print('hello world')", 20);
+	CHECK(strcmp(repl_str(got, sizeof got), "print('hello world')\n") == 0,
+	      "single statement is one clean line -> \"%s\"", got);
+
+	/* 4. An offset (long-write) fragment is refused, not appended. Under
+	 *    NO_OFFSET the controller never delivers this, but the handler
+	 *    rejects it defensively rather than mis-framing the stream. */
+	reset_all();
+	att_write(0, "print('hel", 10);
+	int rc = att_write(10, "lo world')", 10);
+	CHECK(rc == 0x07, "offset write rejected with ATT_ERR_INVALID_OFFSET (rc=0x%02x)", rc);
+	CHECK(strcmp(repl_str(got, sizeof got), "print('hel\n") == 0,
+	      "rejected fragment left no partial state -> \"%s\"", got);
+
+	/* 5. Framed data write stores the payload with the marker stripped. */
+	reset_all();
+	att_write(0, "\x01" "ABCD", 5);
+	CHECK(g_data.len == 4 && memcmp(g_data.buf, "ABCD", 4) == 0,
+	      "data marker stripped, 4 payload bytes stored (got %u)", g_data.len);
+
+	/* 6. Unpaired write is refused. */
+	reset_all();
+	g_paired = false;
+	rc = att_write(0, "print(1)", 8);
+	g_paired = true;
+	CHECK(rc == 0x05 && g_repl.len == 0, "unpaired write rejected (rc=0x%02x)", rc);
+
+	printf(g_fail ? "\nFAILED (%d)\n" : "\nOK\n", g_fail);
+	return g_fail ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

The Lua RX GATT write handler (`on_att_val_set` in `modules/halo/src/ble_lua.c`)
stored `len - 1` bytes on paths where `len` had never been incremented. A
zero-length ATT write reached `ring_buf_put(ring, data, len - 1)`, where the
`uint16_t` `len - 1` promotes to a large `uint32_t` size; an offset
(continuation) write reached the same call without the newline reservation and
lost its last byte, splitting one statement across lines.

This started from #4 by @cjfreeze, who reported and analysed the length
underflow. This PR takes the fuller fix.

## Changes

- Set `NO_OFFSET` on `LUA_IDX_RX_VAL` and `LUA_IDX_AUDIO_RX_VAL`, matching every
  other writable attribute in the database. The controller now refuses offset
  (long/prepared) writes, so one ATT write is one complete message.
- The handler rejects a stray offset defensively (`ATT_ERR_INVALID_OFFSET`),
  ignores a zero-length write, no longer mutates `len`, and appends exactly one
  newline per REPL write. The `current_rx_ring` continuation state machine is
  removed.

The SDK already rejects any payload larger than the ATT MTU and prefixes every
data chunk with the marker, so no client flow depends on offset writes.

## Tests

- `tests/bluetooth/ble_lua_rx/` — host-side reproduction/regression under
  ASan/UBSan. `make run` passes; `make repro` builds the pre-fix logic and
  asserts an AddressSanitizer abort on the length underflow.
- `applications/halo/tests/test_ble_rx_write.py` — unattended on-device test:
  zero-length writes, a zero-length burst, single-line framing, and an over-MTU
  (long) write being refused while the device stays responsive.
- `tests/bluetooth/ble_lua_rx/VALIDATION.md` documents the wider regression
  sweep.

## Validation

Builds clean. Verified on a dev kit: host test green, on-device test 6/6, and a
regression sweep across the data-channel and REPL SDK tests all pass.

Supersedes #4.
