### PR TITLE
ble_lua: route a bare data marker as an empty frame, not REPL input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ release pages and tags are not publicly reachable.
 - BLE Lua RX write handler no longer underflows the ring-buffer length on a
   zero-length or offset write, and continuation fragments no longer drop a
   byte or gain a stray newline (#7)
+- BLE Lua RX handler routes a bare data marker (`send_data("")`) as an empty
+  frame instead of passing the marker byte to the Lua REPL (#8)
 
 ## [0.8.8] - 2026-08-17
 

--- a/modules/halo/src/ble_lua.c
+++ b/modules/halo/src/ble_lua.c
@@ -277,9 +277,17 @@ static void on_att_val_set(uint8_t conidx, uint8_t user_lid, uint16_t token, uin
 			break;
 		}
 
-		if (data[0] == HALO_LUA_CTRL_DATA_MARKER && len >= 2) {
-			/* Framed data: store the payload after the marker byte. */
+		if (data[0] == HALO_LUA_CTRL_DATA_MARKER) {
+			/* Framed data: store the payload after the marker byte. The
+			 * marker is framing, not content, so it must never reach the
+			 * REPL/Lua path - route on it regardless of length and treat a
+			 * bare marker (len == 1) as an empty frame, ignored like a
+			 * zero-length write. */
 			uint16_t payload_len = len - 1;
+
+			if (payload_len == 0) {
+				break;
+			}
 
 			if (ring_buf_space_get(&lua_ctx.data_rx_ring) < payload_len) {
 				LOG_WRN("Data RX ring full (available=%u, needed=%u)",

--- a/tests/bluetooth/ble_lua_rx/main.c
+++ b/tests/bluetooth/ble_lua_rx/main.c
@@ -89,8 +89,11 @@ static int rx_write(uint16_t offset, const uint8_t *data, uint16_t len)
 		ring_buf_reset(&g_data);
 		return 0x00;
 	}
-	if (data[0] == HALO_LUA_CTRL_DATA_MARKER && len >= 2) {
-		uint16_t payload_len = len - 1;
+	if (data[0] == HALO_LUA_CTRL_DATA_MARKER) {
+		uint16_t payload_len = len - 1; /* bare marker (len==1) -> 0 */
+		if (payload_len == 0) {
+			return 0x00; /* empty frame: never reaches the REPL path */
+		}
 		if (ring_buf_space_get(&g_data) < payload_len) {
 			return 0x11; /* ATT_ERR_INSUFF_RESOURCE */
 		}
@@ -228,7 +231,16 @@ int main(void)
 	CHECK(g_data.len == 4 && memcmp(g_data.buf, "ABCD", 4) == 0,
 	      "data marker stripped, 4 payload bytes stored (got %u)", g_data.len);
 
-	/* 6. Unpaired write is refused. */
+	/* 6. A bare data marker (len == 1, e.g. send_data("")) is an empty frame:
+	 *    it must be consumed as framing, never fall through to the REPL ring
+	 *    and reach the Lua parser. */
+	reset_all();
+	rc = att_write(0, "\x01", 1);
+	CHECK(rc == 0x00 && g_repl.len == 0 && g_data.len == 0,
+	      "bare marker is a no-op, not REPL input (repl=%u data=%u)",
+	      g_repl.len, g_data.len);
+
+	/* 7. Unpaired write is refused. */
 	reset_all();
 	g_paired = false;
 	rc = att_write(0, "print(1)", 8);


### PR DESCRIPTION
## Summary

Follow-up to #7, addressing a review note from @cjfreeze.

The RX write handler routed to the data ring only when
`data[0] == DATA_MARKER && len >= 2`. A bare marker (`len == 1`, e.g.
`send_data("")`) failed that guard and fell through to the REPL branch, where
the marker byte itself was stored as a line and handed to the Lua parser. The
marker is framing, not content, so it should never reach the interpreter — a
deterministic syntax error today, but the wrong classification.

## Change

Route on the marker regardless of length, and treat a bare marker as an empty
frame, ignored like a zero-length write. The marker byte can no longer fall
through to the REPL/Lua path.

## Tests

- `tests/bluetooth/ble_lua_rx/` gains a case asserting a bare marker touches
  neither ring (`make run` passes; `make repro` still aborts on the pre-fix
  underflow).
- Verified on a dev kit: the on-device RX test passes, and a regression sweep
  across the data-channel and REPL SDK tests is clean.
